### PR TITLE
Update generate.sh

### DIFF
--- a/src/main/examples/data/generate.sh
+++ b/src/main/examples/data/generate.sh
@@ -47,7 +47,7 @@ do
     echo -e "$word$DELIM$cnt" > generated-data/00/$MINUTE/data
 done
 
-hadoop fs -rmr /data/in/2013/11/15/
-hadoop fs -mkdir /data/in/2013/11/15/
+hadoop fs -rm -r /data/in/2013/11/15/
+hadoop fs -mkdir -p /data/in/2013/11/15/
 hadoop fs -put generated-data/00 /data/in/2013/11/15/ 
 rm -rf generated-data


### PR DESCRIPTION
1. rmr: DEPRECATED: Please use 'rm -r' instead.
2. if parent directorys are not exist, "-mkdir" will fail.