### PR TITLE
[FALCON-1669] add printStackTrace before throw FalconCLIException

### DIFF
--- a/client/src/main/java/org/apache/falcon/client/FalconClient.java
+++ b/client/src/main/java/org/apache/falcon/client/FalconClient.java
@@ -150,6 +150,7 @@ public class FalconClient extends AbstractFalconClient {
             client.resource(UriBuilder.fromUri(baseUrl).build());
             authenticationToken = getToken(baseUrl);
         } catch (Exception e) {
+        	e.printStackTrace();
             throw new FalconCLIException("Unable to initialize Falcon Client object", e);
         }
     }


### PR DESCRIPTION
I think we should print the stacktrace to let user know the root cause of why  Falcon Client object starts fail.