### PR TITLE
FALCON-1782 Client returns FalconWebException instead of the expected…

### DIFF
--- a/prism/src/main/java/org/apache/falcon/resource/AbstractSchedulableEntityManager.java
+++ b/prism/src/main/java/org/apache/falcon/resource/AbstractSchedulableEntityManager.java
@@ -101,9 +101,9 @@ public abstract class AbstractSchedulableEntityManager extends AbstractInstanceM
             }
             LOG.info("Memory lock obtained for {} by {}", entityObj.toShortString(), Thread.currentThread().getName());
             WorkflowEngineFactory.getWorkflowEngine(entityObj, properties).schedule(entityObj, skipDryRun, properties);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             LOG.error("Entity schedule failed for " + type + ": " + entity, e);
-            throw FalconWebException.newAPIException("Entity schedule failed for " + type + ": " + entity);
+            throw FalconWebException.newAPIException(e);
         } finally {
             if (entityObj != null) {
                 memoryLocks.releaseLock(entityObj);


### PR DESCRIPTION
testing :

$ bin/falcon entity -type process -name process1 -properties falcon.scheduler:native -schedule
ERROR: Bad Request;default/Entity process1 is already scheduled on configured workflow engine.