### PR TITLE
FALCON-1783 Fix ProcessUpdateTest and SearchApiTest to use prism

### DIFF
--- a/falcon-regression/CHANGES.txt
+++ b/falcon-regression/CHANGES.txt
@@ -391,6 +391,8 @@ Trunk (Unreleased)
    FALCON-681 delete duplicate feed retention test from falcon regression (SamarthG)
 
   BUG FIXES
+   FALCON-1783 Fix ProcessUpdateTest and SearchApiTest to use prism (Paul Isaychuk)
+
    FALCON-1816 Fix findbugs-exclude.xml path and hadoop version in falcon-regression pom (Paul Isaychuk via Ajay Yadava)
 
    FALCON-1701 HiveDr, ClusterSetupTest, MirrorSummaryTest fixes(Murali Ramasami via Ajay Yadava)

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/ProcessUpdateTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/ProcessUpdateTest.java
@@ -24,7 +24,6 @@ import org.apache.falcon.entity.v0.process.LateProcess;
 import org.apache.falcon.entity.v0.process.PolicyType;
 import org.apache.falcon.regression.Entities.ProcessMerlin;
 import org.apache.falcon.regression.core.bundle.Bundle;
-import org.apache.falcon.regression.core.helpers.ColoHelper;
 import org.apache.falcon.regression.core.util.AssertUtil;
 import org.apache.falcon.regression.core.util.BundleUtil;
 import org.apache.falcon.regression.core.util.InstanceUtil;
@@ -47,7 +46,6 @@ import org.testng.annotations.Test;
 @Test(groups = "embedded")
 public class ProcessUpdateTest extends BaseTestClass {
 
-    private ColoHelper cluster = servers.get(0);
     private OozieClient clusterOC = serverOC.get(0);
     private String baseTestHDFSDir = cleanAndGetTestDir();
     private String aggregateWorkflowDir = baseTestHDFSDir + "/aggregator";
@@ -83,7 +81,7 @@ public class ProcessUpdateTest extends BaseTestClass {
         ProcessMerlin process = bundles[0].getProcessObject();
         process.setValidity(start, end);
         process.setLateProcess(null);
-        cluster.getProcessHelper().submitAndSchedule(process.toString());
+        prism.getProcessHelper().submitAndSchedule(process.toString());
         InstanceUtil.waitTillInstancesAreCreated(clusterOC, process.toString(), 0);
         String bundleId = OozieUtil.getLatestBundleID(clusterOC, process.getName(), EntityType.PROCESS);
 
@@ -97,7 +95,7 @@ public class ProcessUpdateTest extends BaseTestClass {
         lateProcess.getLateInputs().add(lateInput);
         process.setLateProcess(lateProcess);
         LOGGER.info("Updated process xml: " + Util.prettyPrintXml(process.toString()));
-        AssertUtil.assertSucceeded(cluster.getProcessHelper().update(process.toString(), process.toString()));
+        AssertUtil.assertSucceeded(prism.getProcessHelper().update(process.toString(), process.toString()));
 
         //check that new coordinator was created
         String newBundleId = OozieUtil.getLatestBundleID(clusterOC, process.getName(), EntityType.PROCESS);

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/SearchApiTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/SearchApiTest.java
@@ -101,15 +101,15 @@ public class SearchApiTest extends BaseTestClass {
         bundles[0] = BundleUtil.readELBundle();
         bundles[0] = new Bundle(bundles[0], servers.get(0));
         bundles[0].generateUniqueBundle(this);
-        bundles[0].submitClusters(cluster);
+        bundles[0].submitClusters(prism);
         String prefix = base + "-bundle";
 
         FeedMerlin basicFeed = new FeedMerlin(bundles[0].getInputFeedFromBundle());
         basicFeed.setName(prefix + "0-input-feed");
-        AssertUtil.assertSucceeded(cluster.getFeedHelper().submitAndSchedule(basicFeed.toString()));
+        AssertUtil.assertSucceeded(prism.getFeedHelper().submitAndSchedule(basicFeed.toString()));
         basicFeed = new FeedMerlin(bundles[0].getOutputFeedFromBundle());
         basicFeed.setName(prefix + "0-output-feed");
-        AssertUtil.assertSucceeded(cluster.getFeedHelper().submitAndSchedule(basicFeed.toString()));
+        AssertUtil.assertSucceeded(prism.getFeedHelper().submitAndSchedule(basicFeed.toString()));
 
         /* Submit 3 bundles of feeds */
         FeedMerlin feed = new FeedMerlin(bundles[0].getInputFeedFromBundle());
@@ -121,7 +121,7 @@ public class SearchApiTest extends BaseTestClass {
                 tags += ",partial=b1b2";
             }
             feed.setTags(tags);
-            AssertUtil.assertSucceeded(cluster.getFeedHelper().submitEntity(feed.toString()));
+            AssertUtil.assertSucceeded(prism.getFeedHelper().submitEntity(feed.toString()));
         }
 
         /* Submit 3 bundles of processes */
@@ -140,7 +140,7 @@ public class SearchApiTest extends BaseTestClass {
                 tags += ",partial=b1b2";
             }
             process.setTags(tags);
-            AssertUtil.assertSucceeded(cluster.getProcessHelper().submitEntity(process.toString()));
+            AssertUtil.assertSucceeded(prism.getProcessHelper().submitEntity(process.toString()));
 
             //submit a mirroring process
             if (i % 2 == 1) {
@@ -150,7 +150,7 @@ public class SearchApiTest extends BaseTestClass {
             }
             process.setName(prefix + i + "-mirror-process");
             process.setTags(tags);
-            AssertUtil.assertSucceeded(cluster.getProcessHelper().submitEntity(process.toString()));
+            AssertUtil.assertSucceeded(prism.getProcessHelper().submitEntity(process.toString()));
         }
     }
 


### PR DESCRIPTION
We have some weak tests which work in embedded mode, but fail in distributed. Issue exists because in case of distributed mode, entity submit is not allowed via server 