### PR TITLE
FALCON-1823 wrong permissions on folders in distributed mode deb

### DIFF
--- a/src/main/assemblies/distributed-package.xml
+++ b/src/main/assemblies/distributed-package.xml
@@ -30,7 +30,7 @@
             <directory>../src/conf/</directory>
             <outputDirectory>conf</outputDirectory>
             <fileMode>0644</fileMode>
-            <directoryMode>0644</directoryMode>
+            <directoryMode>0755</directoryMode>
             <excludes>
                 <exclude>client.properties</exclude>
                 <exclude>prism-client.properties</exclude>
@@ -113,7 +113,7 @@
             <directory>../hadoop-dependencies/target/dependency</directory>
             <outputDirectory>hadooplibs</outputDirectory>
             <fileMode>0644</fileMode>
-            <directoryMode>0644</directoryMode>
+            <directoryMode>0755</directoryMode>
         </fileSet>
 
         <fileSet>


### PR DESCRIPTION
Testing :

Before:

If we extract the tar in target and run mvn clean install we get error :

rm: cannot remove ‘falcon-distributed-0.10-SNAPSHOT/hadooplibs/curator-framework-2.6.0.jar’: Permission denied
drw-r--r-- 2 praveen praveen 4.0K Feb  5 16:20 conf

There was no read permissions for files under conf because of which prism was not able to start.


After:

drwxr--r-- 2 dataqa dataqa 4.0K Feb  5 16:20 conf

$ bin/prism-start
Hadoop is installed, adding hadoop classpath to falcon classpath
prism started using hadoop version:  Hadoop 2.6.0.2.2.0.0-2041
$ bin/falcon-start
Hadoop is installed, adding hadoop classpath to falcon classpath
falcon started using hadoop version:  Hadoop 2.6.0.2.2.0.0-2041
$ bin/falcon-status
Hadoop is installed, adding hadoop classpath to falcon classpath
falcon process is running with PID: 31752
$ bin/prism-status
Hadoop is installed, adding hadoop classpath to falcon classpath
prism process is running with PID: 3167
