### PR TITLE
FALCON-1811 Status API does not honour start option

### DIFF
--- a/prism/src/main/java/org/apache/falcon/resource/AbstractInstanceManager.java
+++ b/prism/src/main/java/org/apache/falcon/resource/AbstractInstanceManager.java
@@ -465,7 +465,7 @@ public abstract class AbstractInstanceManager extends AbstractEntityManager {
                             : i2.getCluster().compareTo(i1.getCluster());
                 }
             });
-        } else if (orderBy.equals("starttime")){
+        } else if (orderBy.equals("starttime") || orderBy.isEmpty()){
             Collections.sort(instanceSet, new Comparator<Instance>() {
                 @Override
                 public int compare(Instance i1, Instance i2) {
@@ -486,16 +486,7 @@ public abstract class AbstractInstanceManager extends AbstractEntityManager {
                 }
             });
         }
-        Collections.sort(instanceSet, new Comparator<Instance>() {
-            @Override
-            public int compare(Instance i1, Instance i2) {
-                Date start1 = (i1.getStartTime() == null) ? new Date(0) : i1.getStartTime();
-                Date start2 = (i2.getStartTime() == null) ? new Date(0) : i2.getStartTime();
-                return (order.equalsIgnoreCase("asc")) ? start1.compareTo(start2)
-                        : start2.compareTo(start1);
-            }
-        });
-        //Default : startTime
+        //Default : no sort
         return instanceSet;
     }
 

--- a/prism/src/main/java/org/apache/falcon/resource/AbstractInstanceManager.java
+++ b/prism/src/main/java/org/apache/falcon/resource/AbstractInstanceManager.java
@@ -485,8 +485,17 @@ public abstract class AbstractInstanceManager extends AbstractEntityManager {
                             : end2.compareTo(end1);
                 }
             });
-        }//Default : no sort
-
+        }
+        Collections.sort(instanceSet, new Comparator<Instance>() {
+            @Override
+            public int compare(Instance i1, Instance i2) {
+                Date start1 = (i1.getStartTime() == null) ? new Date(0) : i1.getStartTime();
+                Date start2 = (i2.getStartTime() == null) ? new Date(0) : i2.getStartTime();
+                return (order.equalsIgnoreCase("asc")) ? start1.compareTo(start2)
+                        : start2.compareTo(start1);
+            }
+        });
+        //Default : startTime
         return instanceSet;
     }
 

--- a/prism/src/main/java/org/apache/falcon/resource/AbstractInstanceManager.java
+++ b/prism/src/main/java/org/apache/falcon/resource/AbstractInstanceManager.java
@@ -181,7 +181,7 @@ public abstract class AbstractInstanceManager extends AbstractEntityManager {
             if (StringUtils.isNotEmpty(startStr) && StringUtils.isEmpty(sortOrder)){
                 ArrayUtils.reverse(instancesResult.getInstances());
             }
-            instancesResult.setCollection(ArrayUtils.subarray(instancesResult.getInstances(),offset,
+            instancesResult.setCollection(ArrayUtils.subarray(instancesResult.getInstances(), offset,
                     (offset + numResults)));
             return instancesResult;
         } catch (FalconException e) {


### PR DESCRIPTION
$ bin/falcon instance -type process -name process1 -start 2015-10-09T14:00Z -status -numResults 2 
Consolidated Status: SUCCEEDED

Instances:
Instance		Cluster		SourceCluster		Status		Start		End		Details					Log
-----------------------------------------------------------------------------------------------
2015-12-31T01:00Z	local	-	SUSPENDED	2016-02-11T09:34Z	-	-	http://blr-test-129.corp.inmobi.com:11000/oozie?job=0000028-151229192519233-oozie-oozi-W
actions:
 mr-node	null	null
 failed-post-processing	null	null
2016-01-01T01:00Z	local	-	SUSPENDED	2016-02-11T10:18Z	-	-	http://blr-test-129.corp.inmobi.com:11000/oozie?job=0000030-151229192519233-oozie-oozi-W
actions:
 mr-node	null	null
 failed-post-processing	null	null

Additional Information:
Response: default/STATUS
Request Id: default/124451500@qtp-822600088-12 - 2ca2d36d-6e03-4e14-9e97-1448aed90084

Note we will not get the same result when status is waiting as at that time start time is null.
