### PR TITLE
FALCON-1847 Execution order not honored when instances are suspended/resumed

### DIFF
--- a/scheduler/src/main/java/org/apache/falcon/execution/ProcessExecutionInstance.java
+++ b/scheduler/src/main/java/org/apache/falcon/execution/ProcessExecutionInstance.java
@@ -41,6 +41,7 @@ import org.apache.falcon.state.InstanceID;
 import org.apache.falcon.util.RuntimeProperties;
 import org.apache.falcon.workflow.engine.DAGEngine;
 import org.apache.falcon.workflow.engine.DAGEngineFactory;
+import org.apache.falcon.workflow.engine.FalconWorkflowEngine;
 import org.apache.hadoop.fs.Path;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -49,6 +50,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Properties;
 
 
 /**
@@ -269,7 +271,10 @@ public class ProcessExecutionInstance extends ExecutionInstance {
     public void resume() throws FalconException {
         // Was already scheduled on the DAGEngine, so resume on DAGEngine if suspended
         if (getExternalID() != null) {
-            dagEngine.resume(this);
+            if (getProperties() == null) {
+                setProperties(new Properties());
+            }
+            getProperties().setProperty(FalconWorkflowEngine.FALCON_RESUME, "true");
         } else if (awaitedPredicates != null && !awaitedPredicates.isEmpty()) {
             // Evaluate any remaining predicates
             registerForNotifications(true);

--- a/scheduler/src/main/java/org/apache/falcon/execution/ProcessExecutor.java
+++ b/scheduler/src/main/java/org/apache/falcon/execution/ProcessExecutor.java
@@ -267,10 +267,7 @@ public class ProcessExecutor extends EntityExecutor {
     public void resume(ExecutionInstance instance) throws FalconException {
         try {
             instance.resume();
-            if (((ProcessExecutionInstance) instance).isScheduled()) {
-                stateService.handleStateChange(instance, InstanceState.EVENT.RESUME_RUNNING, this);
-                onSchedule(instance);
-            } else if (((ProcessExecutionInstance) instance).isReady()) {
+            if (((ProcessExecutionInstance) instance).isReady()) {
                 stateService.handleStateChange(instance, InstanceState.EVENT.RESUME_READY, this);
                 onConditionsMet(instance);
             } else {

--- a/scheduler/src/main/java/org/apache/falcon/notification/service/impl/JobCompletionService.java
+++ b/scheduler/src/main/java/org/apache/falcon/notification/service/impl/JobCompletionService.java
@@ -139,7 +139,7 @@ public class JobCompletionService implements FalconNotificationService, Workflow
 
     @Override
     public void onSuspend(WorkflowExecutionContext context) throws FalconException {
-        // Do nothing
+        onEnd(context, WorkflowJob.Status.SUSPENDED);
     }
 
     @Override

--- a/scheduler/src/main/java/org/apache/falcon/notification/service/impl/SchedulerService.java
+++ b/scheduler/src/main/java/org/apache/falcon/notification/service/impl/SchedulerService.java
@@ -298,7 +298,9 @@ public class SchedulerService implements FalconNotificationService, Notification
                         if (props != null) {
                             isForced = Boolean.valueOf(props.getProperty(FalconWorkflowEngine.FALCON_FORCE_RERUN));
                         }
-                        if (isReRun(props)) {
+                        if (isResume(props)) {
+                            DAGEngineFactory.getDAGEngine(instance.getCluster()).resume(instance);
+                        } else if (isReRun(props)) {
                             DAGEngineFactory.getDAGEngine(instance.getCluster()).reRun(instance, props, isForced);
                         }
                     } else {
@@ -325,6 +327,13 @@ public class SchedulerService implements FalconNotificationService, Notification
         private boolean isReRun(Properties props) {
             if (props != null && !props.isEmpty()) {
                 return Boolean.valueOf(props.getProperty(FalconWorkflowEngine.FALCON_RERUN));
+            }
+            return false;
+        }
+
+        private boolean isResume(Properties props) {
+            if (props != null && !props.isEmpty()) {
+                return Boolean.valueOf(props.getProperty(FalconWorkflowEngine.FALCON_RESUME));
             }
             return false;
         }

--- a/scheduler/src/main/java/org/apache/falcon/workflow/engine/FalconWorkflowEngine.java
+++ b/scheduler/src/main/java/org/apache/falcon/workflow/engine/FalconWorkflowEngine.java
@@ -68,6 +68,7 @@ public class FalconWorkflowEngine extends AbstractWorkflowEngine {
     private static final String FALCON_INSTANCE_ACTION_CLUSTERS = "falcon.instance.action.clusters";
     public static final String FALCON_FORCE_RERUN = "falcon.system.force.rerun";
     public static final String FALCON_RERUN = "falcon.system.rerun";
+    public static final String FALCON_RESUME = "falcon.system.resume";
 
     private enum JobAction {
         KILL, SUSPEND, RESUME, RERUN, STATUS, SUMMARY, PARAMS
@@ -220,7 +221,9 @@ public class FalconWorkflowEngine extends AbstractWorkflowEngine {
 
         // To ensure compatibility with OozieWorkflowEngine.
         // Also because users would like to see the most recent instances first.
-        sortInstancesDescBySequence(instancesToActOn);
+        if (action == JobAction.STATUS || action == JobAction.PARAMS) {
+            sortInstancesDescBySequence(instancesToActOn);
+        }
 
         List<InstancesResult.Instance> instances = new ArrayList<>();
         for (ExecutionInstance ins : instancesToActOn) {
@@ -298,16 +301,13 @@ public class FalconWorkflowEngine extends AbstractWorkflowEngine {
             populateInstanceInfo(instanceInfo, instance);
             break;
         case STATUS:
-            // Mask wfParams
-            instanceInfo.wfParams = null;
+            populateInstanceInfo(instanceInfo, instance);
+            // If already scheduled externally, get details for actions
             if (StringUtils.isNotEmpty(instance.getExternalID())) {
                 List<InstancesResult.InstanceAction> instanceActions =
                         DAGEngineFactory.getDAGEngine(cluster).getJobDetails(instance.getExternalID());
                 instanceInfo.actions = instanceActions
                         .toArray(new InstancesResult.InstanceAction[instanceActions.size()]);
-            // If not scheduled externally yet, get details from state
-            } else {
-                populateInstanceInfo(instanceInfo, instance);
             }
             break;
         case PARAMS:

--- a/scheduler/src/test/java/org/apache/falcon/execution/FalconExecutionServiceTest.java
+++ b/scheduler/src/test/java/org/apache/falcon/execution/FalconExecutionServiceTest.java
@@ -271,10 +271,12 @@ public class FalconExecutionServiceTest extends AbstractSchedulerTestBase {
         FalconExecutionService.get().resume(process);
         instance1 = stateStore.getExecutionInstance(new InstanceID(instance1.getInstance()));
         instance2 = stateStore.getExecutionInstance(new InstanceID(instance2.getInstance()));
-        Assert.assertEquals(instance1.getCurrentState(), InstanceState.STATE.RUNNING);
+        Assert.assertEquals(instance1.getCurrentState(), InstanceState.STATE.READY);
         Assert.assertEquals(instance2.getCurrentState(), InstanceState.STATE.READY);
 
         // Running should finish after resume
+        event = createEvent(NotificationServicesRegistry.SERVICE.JOB_SCHEDULE, instance1.getInstance());
+        FalconExecutionService.get().onEvent(event);
         event = createEvent(NotificationServicesRegistry.SERVICE.JOB_COMPLETION, instance1.getInstance());
         FalconExecutionService.get().onEvent(event);
 

--- a/scheduler/src/test/java/org/apache/falcon/execution/MockDAGEngine.java
+++ b/scheduler/src/test/java/org/apache/falcon/execution/MockDAGEngine.java
@@ -34,6 +34,7 @@ import java.util.Properties;
 public class MockDAGEngine implements DAGEngine {
     private List<ExecutionInstance> failInstances = new ArrayList<>();
     private Map<ExecutionInstance, Integer> runInvocations =  new HashMap<>();
+    private Map<ExecutionInstance, Integer> resumeInvocations =  new HashMap<>();
 
     public MockDAGEngine(String cluster) {
 
@@ -68,7 +69,13 @@ public class MockDAGEngine implements DAGEngine {
 
     @Override
     public void resume(ExecutionInstance instance) throws DAGEngineException {
+        Integer count = 1;
+        if (resumeInvocations.containsKey(instance)) {
+            // Increment count
+            count = resumeInvocations.get(instance) + 1;
+        }
 
+        resumeInvocations.put(instance, count);
     }
 
     @Override
@@ -124,5 +131,9 @@ public class MockDAGEngine implements DAGEngine {
 
     public Integer getTotalRuns(ExecutionInstance instance) {
         return runInvocations.get(instance);
+    }
+
+    public Integer getTotalResumes(ExecutionInstance instance) {
+        return resumeInvocations.get(instance);
     }
 }

--- a/webapp/src/test/java/org/apache/falcon/resource/InstanceSchedulerManagerJerseyIT.java
+++ b/webapp/src/test/java/org/apache/falcon/resource/InstanceSchedulerManagerJerseyIT.java
@@ -121,7 +121,10 @@ public class InstanceSchedulerManagerJerseyIT extends AbstractSchedulerManagerJe
                 END_TIME, colo, null, null, null, null);
         status = getClient().getInstanceStatus(EntityType.PROCESS.name(),
                 processName, START_INSTANCE);
-        Assert.assertEquals(status, InstancesResult.WorkflowStatus.RUNNING);
+        Assert.assertEquals(status, InstancesResult.WorkflowStatus.READY);
+
+        waitForStatus(EntityType.PROCESS.toString(), processName,
+                START_INSTANCE, InstancesResult.WorkflowStatus.RUNNING);
     }
 
     @Test


### PR DESCRIPTION
Have made the following changes:

1. Order of instances on which we perform action is sorted in desc only for status and params. Else, older instances should be suspended/resumed first.
2. Status is now read from DB and only additional info is obtained from Oozie.
3. Listening to suspend notification too, so further instances can be scheduled.
4. Resume does not immediately resume the instance in order to honor concurrency.