### PR TITLE
FALCON-1852 Make optional input to a process truly optional

### DIFF
--- a/common/src/main/java/org/apache/falcon/entity/ClusterHelper.java
+++ b/common/src/main/java/org/apache/falcon/entity/ClusterHelper.java
@@ -42,7 +42,7 @@ public final class ClusterHelper {
     public static final String DEFAULT_BROKER_IMPL_CLASS = "org.apache.activemq.ActiveMQConnectionFactory";
     public static final String WORKINGDIR = "working";
     public static final String NO_USER_BROKER_URL = "NA";
-
+    public static final String EMPTY_DIR_NAME = "EMPTY_DIR_DONT_DELETE";
 
 
     private ClusterHelper() {
@@ -191,5 +191,10 @@ public final class ClusterHelper {
             }
         }
         return null;
+    }
+
+    public static String getEmptyDir(Cluster cluster) {
+        return getStorageUrl(cluster) + getLocation(cluster, ClusterLocationType.STAGING).getPath()
+                + "/" + EMPTY_DIR_NAME;
     }
 }

--- a/common/src/main/java/org/apache/falcon/entity/parser/ClusterEntityParser.java
+++ b/common/src/main/java/org/apache/falcon/entity/parser/ClusterEntityParser.java
@@ -301,6 +301,10 @@ public class ClusterEntityParser extends EntityParser<Cluster> {
                     "falcon/workflows/feed", HadoopClientFactory.ALL_PERMISSION);
             createStagingSubdirs(fs, cluster, stagingLocation,
                     "falcon/workflows/process", HadoopClientFactory.ALL_PERMISSION);
+
+            // Create empty dirs for optional input
+            createStagingSubdirs(fs, cluster, stagingLocation,
+                    ClusterHelper.EMPTY_DIR_NAME, HadoopClientFactory.READ_ONLY_PERMISSION);
         }
     }
 

--- a/common/src/main/java/org/apache/falcon/hadoop/HadoopClientFactory.java
+++ b/common/src/main/java/org/apache/falcon/hadoop/HadoopClientFactory.java
@@ -57,6 +57,8 @@ public final class HadoopClientFactory {
             new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL);
 
     private static final HadoopClientFactory INSTANCE = new HadoopClientFactory();
+    public static final FsPermission READ_ONLY_PERMISSION =
+            new FsPermission(FsAction.READ, FsAction.READ, FsAction.READ);
 
     private HadoopClientFactory() {
     }

--- a/common/src/test/java/org/apache/falcon/entity/parser/ClusterEntityParserTest.java
+++ b/common/src/test/java/org/apache/falcon/entity/parser/ClusterEntityParserTest.java
@@ -347,8 +347,8 @@ public class ClusterEntityParserTest extends AbstractTestBase {
         Mockito.doNothing().when(clusterEntityParser).validateWorkflowInterface(cluster);
         Mockito.doNothing().when(clusterEntityParser).validateMessagingInterface(cluster);
         Mockito.doNothing().when(clusterEntityParser).validateRegistryInterface(cluster);
-        this.dfsCluster.getFileSystem().mkdirs(new Path(ClusterHelper.getLocation(cluster,
-                ClusterLocationType.STAGING).getPath()), HadoopClientFactory.ALL_PERMISSION);
+        String stagingPath = ClusterHelper.getLocation(cluster, ClusterLocationType.STAGING).getPath();
+        this.dfsCluster.getFileSystem().mkdirs(new Path(stagingPath), HadoopClientFactory.ALL_PERMISSION);
         clusterEntityParser.validate(cluster);
         String workingDirPath = cluster.getLocations().getLocations().get(0).getPath() + "/working";
         Assert.assertEquals(ClusterHelper.getLocation(cluster, ClusterLocationType.WORKING).getPath(), workingDirPath);
@@ -356,6 +356,11 @@ public class ClusterEntityParserTest extends AbstractTestBase {
         Assert.assertTrue(workingDirStatus.isDirectory());
         Assert.assertEquals(workingDirStatus.getPermission(), HadoopClientFactory.READ_EXECUTE_PERMISSION);
         Assert.assertEquals(workingDirStatus.getOwner(), UserGroupInformation.getLoginUser().getShortUserName());
+
+        FileStatus emptyDirStatus = this.dfsCluster.getFileSystem().getFileStatus(new Path(stagingPath
+                + "/" + ClusterHelper.EMPTY_DIR_NAME));
+        Assert.assertEquals(emptyDirStatus.getPermission(), HadoopClientFactory.READ_ONLY_PERMISSION);
+        Assert.assertEquals(emptyDirStatus.getOwner(), UserGroupInformation.getLoginUser().getShortUserName());
 
         String stagingSubdirFeed = cluster.getLocations().getLocations().get(0).getPath() + "/falcon/workflows/feed";
         String stagingSubdirProcess =

--- a/docs/src/site/twiki/EntitySpecification.twiki
+++ b/docs/src/site/twiki/EntitySpecification.twiki
@@ -682,8 +682,7 @@ Example workflow configuration:
 
 
 ---+++ Optional Inputs
-User can mention one or more inputs as optional inputs. In such cases the job does not wait on those inputs which are
-mentioned as optional. If they are present it considers them otherwise continue with the compulsory ones.
+User can mention one or more inputs as optional inputs. In such cases the job does not wait on those inputs which are mentioned as optional. If they are present it considers them otherwise continues with the mandatory ones. If some instances of the optional feed are present for the given data window, those are considered and passed on to the process. While checking for presence of an feed instance, Falcon looks for __availabilityFlag__ in the directory, if specified in the feed definition. If no __availabilityFlag__ is specified, presence of the instance directory is treated as indication of availability of data.
 Example:
 <verbatim>
 <feed name="feed1">

--- a/oozie-el-extensions/pom.xml
+++ b/oozie-el-extensions/pom.xml
@@ -82,6 +82,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/oozie/src/main/java/org/apache/falcon/oozie/process/ProcessBundleBuilder.java
+++ b/oozie/src/main/java/org/apache/falcon/oozie/process/ProcessBundleBuilder.java
@@ -20,6 +20,7 @@ package org.apache.falcon.oozie.process;
 
 import org.apache.falcon.FalconException;
 import org.apache.falcon.Tag;
+import org.apache.falcon.entity.ClusterHelper;
 import org.apache.falcon.entity.EntityUtil;
 import org.apache.falcon.entity.FeedHelper;
 import org.apache.falcon.entity.v0.EntityType;
@@ -65,12 +66,13 @@ public class ProcessBundleBuilder extends OozieBundleBuilder<Process> {
                     properties.put(inName + ".end_of_duration", Timeunit.NONE.name());
                     properties.put(inName + ".initial-instance",
                         SchemaHelper.formatDateUTC(feedCluster.getValidity().getStart()));
-                    properties.put(inName + ".done-flag", "notused");
+                    String doneFlag = feed.getAvailabilityFlag();
+                    properties.put(inName + ".done-flag", (doneFlag == null)? "" : doneFlag);
 
                     String locPath = FeedHelper.createStorage(cluster.getName(), feed)
                         .getUriTemplate(LocationType.DATA).replace('$', '%');
                     properties.put(inName + ".uri-template", locPath);
-
+                    properties.put(inName + ".empty-dir", ClusterHelper.getEmptyDir(cluster));
                     properties.put(inName + ".start-instance", in.getStart());
                     properties.put(inName + ".end-instance", in.getEnd());
                 }

--- a/oozie/src/main/java/org/apache/falcon/oozie/process/ProcessExecutionCoordinatorBuilder.java
+++ b/oozie/src/main/java/org/apache/falcon/oozie/process/ProcessExecutionCoordinatorBuilder.java
@@ -158,20 +158,20 @@ public class ProcessExecutionCoordinatorBuilder extends OozieCoordinatorBuilder<
             Feed feed = EntityUtil.getEntity(EntityType.FEED, input.getFeed());
             Storage storage = FeedHelper.createStorage(cluster, feed);
 
+            if (coord.getDatasets() == null) {
+                coord.setDatasets(new DATASETS());
+            }
+
+            SYNCDATASET syncdataset = createDataSet(feed, cluster, storage, input.getName(), LocationType.DATA);
+            if (syncdataset == null) {
+                return;
+            }
+            coord.getDatasets().getDatasetOrAsyncDataset().add(syncdataset);
+
             if (!input.isOptional()) {
-                if (coord.getDatasets() == null) {
-                    coord.setDatasets(new DATASETS());
-                }
                 if (coord.getInputEvents() == null) {
                     coord.setInputEvents(new INPUTEVENTS());
                 }
-
-                SYNCDATASET syncdataset = createDataSet(feed, cluster, storage, input.getName(), LocationType.DATA);
-                if (syncdataset == null) {
-                    return;
-                }
-                coord.getDatasets().getDatasetOrAsyncDataset().add(syncdataset);
-
                 DATAIN datain = createDataIn(input);
                 coord.getInputEvents().getDataIn().add(datain);
             }

--- a/webapp/src/test/java/org/apache/falcon/resource/EntityManagerJerseyIT.java
+++ b/webapp/src/test/java/org/apache/falcon/resource/EntityManagerJerseyIT.java
@@ -198,6 +198,8 @@ public class EntityManagerJerseyIT extends AbstractSchedulerManagerJerseyIT {
         File tmpFile = TestContext.getTempFile();
         EntityType.PROCESS.getMarshaller().marshal(process, tmpFile);
         schedule(context);
+        waitForStatus(EntityType.PROCESS.name(), context.getProcessName(), START_INSTANCE,
+                InstancesResult.WorkflowStatus.SUCCEEDED);
     }
 
     public void testDryRun() throws Exception {


### PR DESCRIPTION
The following changes have been made:
1. Creation of "empty dir" under the staging path of a cluster (during cluster creation).
2. Modify OozieELExtensions to look for availability flag and use only those instances that have the entire dataset. Use "empty dir" when no instances resolve.
3. Updated UT and IT for additional validation.

Tested manually with and without availabilityFlag supplied.