### PR TITLE
FALCON-1874 Import and Export fails with HDFS as src/dest

### DIFF
--- a/oozie/src/main/java/org/apache/falcon/oozie/DatabaseExportWorkflowBuilder.java
+++ b/oozie/src/main/java/org/apache/falcon/oozie/DatabaseExportWorkflowBuilder.java
@@ -64,8 +64,7 @@ public class DatabaseExportWorkflowBuilder extends ExportWorkflowBuilder {
         org.apache.falcon.oozie.sqoop.ACTION sqoopExport = actionJaxbElement.getValue();
 
         Properties props = new Properties();
-        ImportExportCommon.addHCatalogProperties(props, entity, cluster, workflow, this, buildPath);
-        sqoopExport.getJobXml().add("${wf:appPath()}/conf/hive-site.xml");
+        ImportExportCommon.addHCatalogProperties(props, entity, cluster, workflow, this, buildPath, sqoopExport);
         OozieUtils.marshalSqoopAction(action, actionJaxbElement);
 
         addTransition(action, SUCCESS_POSTPROCESS_ACTION_NAME, FAIL_POSTPROCESS_ACTION_NAME);

--- a/oozie/src/main/java/org/apache/falcon/oozie/DatabaseImportWorkflowBuilder.java
+++ b/oozie/src/main/java/org/apache/falcon/oozie/DatabaseImportWorkflowBuilder.java
@@ -66,8 +66,7 @@ public class DatabaseImportWorkflowBuilder extends ImportWorkflowBuilder {
         org.apache.falcon.oozie.sqoop.ACTION sqoopImport = actionJaxbElement.getValue();
 
         Properties props = new Properties();
-        ImportExportCommon.addHCatalogProperties(props, entity, cluster, workflow, this, buildPath);
-        sqoopImport.getJobXml().add("${wf:appPath()}/conf/hive-site.xml");
+        ImportExportCommon.addHCatalogProperties(props, entity, cluster, workflow, this, buildPath, sqoopImport);
         OozieUtils.marshalSqoopAction(action, actionJaxbElement);
 
         addTransition(action, SUCCESS_POSTPROCESS_ACTION_NAME, FAIL_POSTPROCESS_ACTION_NAME);

--- a/oozie/src/main/java/org/apache/falcon/oozie/FeedExportCoordinatorBuilder.java
+++ b/oozie/src/main/java/org/apache/falcon/oozie/FeedExportCoordinatorBuilder.java
@@ -125,7 +125,6 @@ public class FeedExportCoordinatorBuilder extends OozieCoordinatorBuilder<Feed> 
         datain.setDataset(EXPORT_DATASET_NAME);
         org.apache.falcon.entity.v0.feed.Cluster feedCluster = FeedHelper.getCluster(feed, cluster.getName());
         datain.getInstance().add(SchemaHelper.formatDateUTC(feedCluster.getValidity().getStart()));
-        datain.getInstance().add(SchemaHelper.formatDateUTC(feedCluster.getValidity().getStart()));
         return datain;
     }
 

--- a/oozie/src/main/java/org/apache/falcon/oozie/ImportExportCommon.java
+++ b/oozie/src/main/java/org/apache/falcon/oozie/ImportExportCommon.java
@@ -28,6 +28,7 @@ import org.apache.falcon.entity.v0.datasource.Credential;
 import org.apache.falcon.entity.v0.datasource.Credentialtype;
 import org.apache.falcon.entity.v0.datasource.Datasource;
 import org.apache.falcon.entity.v0.feed.Feed;
+import org.apache.falcon.oozie.sqoop.ACTION;
 import org.apache.falcon.oozie.workflow.WORKFLOWAPP;
 import org.apache.falcon.security.SecurityUtil;
 import org.apache.hadoop.fs.Path;
@@ -88,7 +89,8 @@ public final class ImportExportCommon {
     }
 
     public static void addHCatalogProperties(Properties props, Feed entity, Cluster cluster,
-        WORKFLOWAPP workflow, OozieOrchestrationWorkflowBuilder<Feed> wBuilder, Path buildPath)
+                                             WORKFLOWAPP workflow, OozieOrchestrationWorkflowBuilder<Feed> wBuilder,
+                                             Path buildPath, ACTION sqoopAction)
         throws FalconException {
         if (FeedHelper.getStorageType(entity, cluster) == Storage.TYPE.TABLE) {
             wBuilder.createHiveConfiguration(cluster, buildPath, "");
@@ -98,6 +100,7 @@ public final class ImportExportCommon {
                 wBuilder.addHCatalogCredentials(workflow, cluster,
                         OozieOrchestrationWorkflowBuilder.HIVE_CREDENTIAL_NAME, FALCON_IMPORT_SQOOP_ACTIONS);
             }
+            sqoopAction.getJobXml().add("${wf:appPath()}/conf/hive-site.xml");
         }
     }
     private static void addHCatalogShareLibs(Properties props) throws FalconException {


### PR DESCRIPTION
1. job-xml was pointing to hive-site.xml even for HDFS, cause workflow to fail.
2. datain element was repeated in export coordinator, causing workflow to fail.