### PR TITLE
Falcon webUI returns 413

### DIFF
--- a/prism/src/main/java/org/apache/falcon/util/SecureEmbeddedServer.java
+++ b/prism/src/main/java/org/apache/falcon/util/SecureEmbeddedServer.java
@@ -48,6 +48,13 @@ public class SecureEmbeddedServer extends EmbeddedServer {
         connector.setPassword(properties.getProperty("password",
                 System.getProperty("password", "falcon-prism-passwd")));
         connector.setWantClientAuth(true);
+
+        // this is to enable large header sizes when Kerberos is enabled with AD
+        final Integer bufferSize = Integer.valueOf(StartupProperties.get().getProperty(
+                "falcon.jetty.request.buffer.size", "16192"));
+        connector.setHeaderBufferSize(bufferSize);
+        connector.setRequestBufferSize(bufferSize);
+
         return connector;
     }
 }


### PR DESCRIPTION
 (Full head - Request entity too large) error when TLS is enabled in a secure cluster with AD integration)

Fix is to duplicate the SocketConnector change to increase header and request buffer for Jetty based on startup properties