### PR TITLE
FALCON-1855: Falcon regression build fails with checkstyle issues

### DIFF
--- a/falcon-regression/pom.xml
+++ b/falcon-regression/pom.xml
@@ -433,13 +433,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.falcon</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>${project.version}</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <id>checkstyle-check</id>
@@ -450,8 +443,8 @@
                         <configuration>
                             <consoleOutput>true</consoleOutput>
                             <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                            <configLocation>falcon/checkstyle.xml</configLocation>
-                            <headerLocation>falcon/checkstyle-java-header.txt</headerLocation>
+			    <configLocation>src/build/checkstyle.xml</configLocation>
+			    <headerLocation>src/build/checkstyle-java-header.txt</headerLocation>
                             <failOnViolation>true</failOnViolation>
                             <skip>${skipCheck}</skip>
                             <excludes>**/entity/v0/*/**</excludes>


### PR DESCRIPTION
Falcon checkstyle is now moved to parent pom because of which regression is failing. Fixing the path 