### PR TITLE
FALCON-1931 : Adding multiCluster tag for Multiple Cluster scenarios

### DIFF
--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/FeedLateRerunTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/FeedLateRerunTest.java
@@ -56,7 +56,7 @@ import java.util.List;
  * On adding further late data it checks whether the data has been replicated correctly in the given late cut-off time.
  * Assuming that late frequency set in server is 3 minutes. Although value can be changed according to requirement.
  */
-@Test(groups = { "distributed", "embedded", "sanity" })
+@Test(groups = { "distributed", "embedded", "sanity", "multiCluster" })
 public class FeedLateRerunTest extends BaseTestClass {
 
     private ColoHelper cluster1 = servers.get(0);

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/FeedReplicationTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/FeedReplicationTest.java
@@ -60,7 +60,7 @@ import java.util.Map;
  * feed replication test.
  * Replicates empty directories as well as directories containing data.
  */
-@Test(groups = { "distributed", "embedded", "sanity" })
+@Test(groups = { "distributed", "embedded", "sanity", "multiCluster" })
 public class FeedReplicationTest extends BaseTestClass {
 
     private ColoHelper cluster1 = servers.get(0);
@@ -401,7 +401,7 @@ public class FeedReplicationTest extends BaseTestClass {
      * Test for https://issues.apache.org/jira/browse/FALCON-668.
      * Check that new DistCp options are allowed.
      */
-    @Test
+    @Test(dataProvider = "dataFlagProvider")
     public void testNewDistCpOptions() throws Exception {
         Bundle.submitCluster(bundles[0], bundles[1]);
         String startTime = TimeUtil.getTimeWrtSystemTime(0);
@@ -503,7 +503,7 @@ public class FeedReplicationTest extends BaseTestClass {
      * Test demonstrates failure pf replication of stored data from one source cluster to one target cluster.
      * When replication job fails test checks if failed logs are present in staging directory or not.
      */
-    @Test
+    @Test(dataProvider = "dataFlagProvider")
     public void replicate1Source1TargetFail()
         throws Exception {
         Bundle.submitCluster(bundles[0], bundles[1]);

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/FeedReplicationTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/FeedReplicationTest.java
@@ -401,7 +401,7 @@ public class FeedReplicationTest extends BaseTestClass {
      * Test for https://issues.apache.org/jira/browse/FALCON-668.
      * Check that new DistCp options are allowed.
      */
-    @Test(dataProvider = "dataFlagProvider")
+    @Test
     public void testNewDistCpOptions() throws Exception {
         Bundle.submitCluster(bundles[0], bundles[1]);
         String startTime = TimeUtil.getTimeWrtSystemTime(0);
@@ -503,7 +503,7 @@ public class FeedReplicationTest extends BaseTestClass {
      * Test demonstrates failure pf replication of stored data from one source cluster to one target cluster.
      * When replication job fails test checks if failed logs are present in staging directory or not.
      */
-    @Test(dataProvider = "dataFlagProvider")
+    @Test
     public void replicate1Source1TargetFail()
         throws Exception {
         Bundle.submitCluster(bundles[0], bundles[1]);

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/InstanceSummaryTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/InstanceSummaryTest.java
@@ -173,7 +173,7 @@ public class InstanceSummaryTest extends BaseTestClass {
     /**
      * Adjust multi-cluster process. Submit and schedule it. Get its instances summary.
      */
-    @Test(enabled = true, timeOut = 1200000)
+    @Test(enabled = true, timeOut = 1200000, groups = "multiCluster")
     public void testSummaryMultiClusterProcess() throws JAXBException,
             ParseException, IOException, URISyntaxException, AuthenticationException,
             InterruptedException {
@@ -208,7 +208,7 @@ public class InstanceSummaryTest extends BaseTestClass {
     /**
      *  Adjust multi-cluster feed. Submit and schedule it. Get its instances summary.
      */
-    @Test(enabled = true, timeOut = 1200000)
+    @Test(enabled = true, timeOut = 1200000, groups = "multiCluster")
     public void testSummaryMultiClusterFeed() throws JAXBException, ParseException, IOException,
             URISyntaxException, OozieClientException, AuthenticationException,
             InterruptedException {

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/ProcessInstanceColoMixedTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/ProcessInstanceColoMixedTest.java
@@ -48,7 +48,7 @@ import java.util.List;
 /**
  * Process instance mixed colo tests.
  */
-@Test(groups = { "distributed", "embedded" })
+@Test(groups = { "distributed", "embedded", "multiCluster" })
 public class ProcessInstanceColoMixedTest extends BaseTestClass {
 
     private final String baseTestHDFSDir = cleanAndGetTestDir();

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/hcat/HCatFeedOperationsTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/hcat/HCatFeedOperationsTest.java
@@ -119,7 +119,7 @@ public class HCatFeedOperationsTest extends BaseTestClass {
      *
      * @throws Exception
      */
-    @Test(groups = {"singleCluster"})
+    @Test(groups = {"multiCluster"})
     public void submitFeedWhenTableDoesNotExist() throws Exception {
         Bundle.submitCluster(bundles[1]);
         feed = bundles[1].getInputFeedFromBundle();
@@ -159,7 +159,7 @@ public class HCatFeedOperationsTest extends BaseTestClass {
      *
      * @throws Exception
      */
-    @Test
+    @Test(groups = {"multiCluster"})
     public void submitAndScheduleReplicationFeedWhenTableExistsOnSourceAndTarget() throws Exception {
         Bundle.submitCluster(bundles[0], bundles[1]);
         final String startDate = "2010-01-01T20:00Z";
@@ -192,7 +192,7 @@ public class HCatFeedOperationsTest extends BaseTestClass {
      *
      * @throws Exception
      */
-    @Test
+    @Test(groups = {"multiCluster"})
     public void suspendAndResumeReplicationFeed() throws Exception {
 
         submitAndScheduleReplicationFeedWhenTableExistsOnSourceAndTarget();
@@ -215,7 +215,7 @@ public class HCatFeedOperationsTest extends BaseTestClass {
      *
      * @throws Exception
      */
-    @Test
+    @Test(groups = {"multiCluster"})
     public void deleteReplicationFeed() throws Exception {
         submitAndScheduleReplicationFeedWhenTableExistsOnSourceAndTarget();
 

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/hcat/HCatReplicationTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/hcat/HCatReplicationTest.java
@@ -64,7 +64,7 @@ import java.util.Map;
 /**
  * Tests for replication with hcat.
  */
-@Test(groups = "embedded")
+@Test(groups = {"embedded", "multiCluster"})
 public class HCatReplicationTest extends BaseTestClass {
 
     private static final Logger LOGGER = Logger.getLogger(HCatReplicationTest.class);

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/hive/dr/HdfsRecipeTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/hive/dr/HdfsRecipeTest.java
@@ -50,7 +50,7 @@ import java.util.List;
 /**
  * Hdfs recipe test.
  */
-@Test(groups = "embedded")
+@Test(groups = {"embedded", "multiCluster"})
 public class HdfsRecipeTest extends BaseTestClass {
     private static final Logger LOGGER = Logger.getLogger(HdfsRecipeTest.class);
     private final ColoHelper cluster = servers.get(0);

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/hive/dr/HiveDRTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/hive/dr/HiveDRTest.java
@@ -65,7 +65,7 @@ import static org.apache.falcon.regression.hive.dr.HiveObjectCreator.createVanil
 /**
  * Hive DR Testing.
  */
-@Test(groups = "embedded")
+@Test(groups = {"embedded", "multiCluster"})
 public class HiveDRTest extends BaseTestClass {
     private static final Logger LOGGER = Logger.getLogger(HiveDRTest.class);
     private static final String DB_NAME = "hdr_sdb1";

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/hive/dr/HiveDbDRTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/hive/dr/HiveDbDRTest.java
@@ -59,7 +59,7 @@ import static org.apache.falcon.regression.hive.dr.HiveObjectCreator.createVanil
 /**
  * Hive DR Testing for Hive database replication.
  */
-@Test(groups = "embedded")
+@Test(groups = {"embedded", "multiCluster"})
 public class HiveDbDRTest extends BaseTestClass {
     private static final Logger LOGGER = Logger.getLogger(HiveDbDRTest.class);
     private final ColoHelper cluster = servers.get(0);

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/lineage/EntitySummaryTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/lineage/EntitySummaryTest.java
@@ -128,7 +128,7 @@ public class EntitySummaryTest extends BaseTestClass {
      * Get status of 7 feeds and 7 instances of each feed the call should give correct information,
      * instance info must be recent.
      */
-    @Test
+    @Test(groups = "multiCluster")
     public void getFeedSummary() throws Exception {
         //prepare feed template.
         bundles[0].setInputFeedPeriodicity(5, Frequency.TimeUnit.minutes);

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/lineage/ListFeedInstancesTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/lineage/ListFeedInstancesTest.java
@@ -59,7 +59,7 @@ import java.util.List;
  * expected instance statuses which are being compared with actual result of -list request
  * with different parameters in different order, variation, etc.
  */
-@Test(groups = { "distributed", "embedded", "sanity" })
+@Test(groups = { "distributed", "embedded", "sanity", "multiCluster"})
 public class ListFeedInstancesTest extends BaseTestClass {
     private static final Logger LOGGER = Logger.getLogger(ListFeedInstancesTest.class);
     private OozieClient cluster2OC = serverOC.get(1);

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/nativeScheduler/NativeScheduleTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/nativeScheduler/NativeScheduleTest.java
@@ -184,7 +184,7 @@ public class NativeScheduleTest extends BaseTestClass {
      * Successfully schedule process via native scheduler through prism and server on multiple cluster.
      * Schedule the same process on oozie. It should fail.
      */
-    @Test(groups = {"prism", "0.2"})
+    @Test(groups = {"prism", "0.2", "multiCluster"})
     public void scheduleProcessWithNativeOnTwoClusters() throws Exception {
 
         ProcessMerlin processMerlinNative = bundles[0].getProcessObject();

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/prism/PrismFeedReplicationUpdateTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/prism/PrismFeedReplicationUpdateTest.java
@@ -49,7 +49,7 @@ import java.io.IOException;
 /**
  * Update replication feed tests.
  */
-@Test(groups = { "distributed", "embedded" })
+@Test(groups = { "distributed", "embedded", "multiCluster" })
 public class PrismFeedReplicationUpdateTest extends BaseTestClass {
 
     private ColoHelper cluster1 = servers.get(0);

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/prism/PrismFeedScheduleTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/prism/PrismFeedScheduleTest.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 /**
  * Schedule feed via prism tests.
  */
-@Test(groups = { "distributed", "embedded" })
+@Test(groups = { "distributed", "embedded", "multiCluster"})
 public class PrismFeedScheduleTest extends BaseTestClass {
 
     private OozieClient cluster1OC = serverOC.get(0);

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/prism/PrismFeedUpdateTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/prism/PrismFeedUpdateTest.java
@@ -96,7 +96,7 @@ public class PrismFeedUpdateTest extends BaseTestClass {
      * Set 2 processes with common output feed. Second one is zero-input process. Update feed
      * queue. TODO : complete test case
      */
-    @Test(enabled = true, timeOut = 1200000)
+    @Test(enabled = true, timeOut = 1200000 , groups = "multiCluster")
     public void updateFeedQueueDependentMultipleProcessOneProcessZeroInput() throws Exception {
         //cluster1colo and cluster2colo are source. feed01 on cluster1colo target cluster2colo,
         // feed02 on cluster2colo target cluster1colo

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/prism/PrismProcessSnSTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/prism/PrismProcessSnSTest.java
@@ -80,7 +80,7 @@ public class PrismProcessSnSTest extends BaseTestClass {
      * Submit and schedule process2 on cluster2. Check that process2 is running and process1 is
      * not running on cluster2.
      */
-    @Test(groups = {"prism", "0.2", "embedded"})
+    @Test(groups = {"prism", "0.2", "embedded", "multiCluster"})
     public void testProcessSnSOnBothColos() throws Exception {
         //schedule both bundles
         bundles[0].submitAndScheduleProcess();
@@ -100,7 +100,7 @@ public class PrismProcessSnSTest extends BaseTestClass {
      * on cluster2. Submit process2 but schedule process1 once more. Check that process1 is running
      * on cluster1 but not on cluster2.
      */
-    @Test(groups = {"prism", "0.2", "embedded"})
+    @Test(groups = {"prism", "0.2", "embedded", "multiCluster"})
     public void testProcessSnSForSubmittedProcessOnBothColos() throws Exception {
         //schedule both bundles
         bundles[0].submitProcess(true);
@@ -122,7 +122,7 @@ public class PrismProcessSnSTest extends BaseTestClass {
      * once more and check that it is still running on cluster1 but process2 isn't running on
      * cluster2.
      */
-    @Test(groups = {"prism", "0.2", "embedded"})
+    @Test(groups = {"prism", "0.2", "embedded", "multiCluster"})
     public void testProcessSnSForSubmittedProcessOnBothColosUsingColoHelper()
         throws Exception {
         bundles[0].submitProcess(true);
@@ -228,7 +228,7 @@ public class PrismProcessSnSTest extends BaseTestClass {
      * running. Delete both of them. Submit and schedule them once more. Check that they are
      * running again.
      */
-    @Test(groups = {"prism", "0.2", "embedded"})
+    @Test(groups = {"prism", "0.2", "embedded", "multiCluster"})
     public void testSnSDeletedProcessOnBothColos() throws Exception {
         //schedule both bundles
         final String cluster1Running = cluster1.getClusterHelper().getColoName() + "/RUNNING";

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/searchUI/MirrorTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/searchUI/MirrorTest.java
@@ -56,7 +56,7 @@ import java.sql.Connection;
 import java.util.Arrays;
 
 /** UI tests for Mirror Setup Wizard. */
-@Test(groups = "search-ui")
+@Test(groups = {"search-ui", "multiCluster"})
 public class MirrorTest extends BaseUITestClass {
     private static final Logger LOGGER = Logger.getLogger(MirrorTest.class);
     private final String baseTestDir = cleanAndGetTestDir();


### PR DESCRIPTION
In the regression test suite, there are lot of places multiCluster annotation has been defined to denote it uses multiple cluster. It is very useful annotation since we require additional cluster and setup to test the test case . Some of the major test cases such as feed replication and Hive DR are missing this annotation. 