### PR TITLE
FALCON-1919 Provide user the option to store sensitive information with Hadoop credential provider

### DIFF
--- a/common/src/main/java/org/apache/falcon/security/CredentialProviderHelper.java
+++ b/common/src/main/java/org/apache/falcon/security/CredentialProviderHelper.java
@@ -18,11 +18,11 @@
 
 package org.apache.falcon.security;
 
+import org.apache.falcon.FalconException;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -72,18 +72,18 @@ public final class CredentialProviderHelper {
                 || methFlush == null);
     }
 
-    public static String resolveAlias(Configuration conf, String alias) throws IOException {
+    public static String resolveAlias(Configuration conf, String alias) throws FalconException {
         try {
             char[] cred = (char[]) methGetPassword.invoke(conf, alias);
             if (cred == null) {
-                throw new IOException("The provided alias cannot be resolved");
+                throw new FalconException("The provided alias cannot be resolved");
             }
             return new String(cred);
         } catch (InvocationTargetException ite) {
-            throw new RuntimeException("Error resolving password "
+            throw new FalconException("Error resolving password "
                     + " from the credential providers ", ite.getTargetException());
         } catch (IllegalAccessException iae) {
-            throw new RuntimeException("Error invoking the credential provider method", iae);
+            throw new FalconException("Error invoking the credential provider method", iae);
         }
     }
 }

--- a/common/src/main/java/org/apache/falcon/util/StartupProperties.java
+++ b/common/src/main/java/org/apache/falcon/util/StartupProperties.java
@@ -20,8 +20,6 @@ package org.apache.falcon.util;
 
 import org.apache.falcon.FalconException;
 import org.apache.falcon.hadoop.HadoopClientFactory;
-import org.apache.falcon.security.CredentialProviderHelper;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
@@ -39,8 +37,6 @@ public final class StartupProperties extends ApplicationProperties {
     public static final String SAFEMODE_PROPERTY = "falcon.safeMode";
     private static final String SAFEMODE_FILE = ".safemode";
     private static final String CONFIGSTORE_PROPERTY = "config.store.uri";
-    private static final String CREDENTIAL_PROVIDER_PROPERTY = "hadoop.security.credential.provider.path";
-    private static final String ALIAS_PROPERTY_PREFIX = "hadoop.security.alias.";
 
     private static FileSystem fileSystem;
     private static Path storePath;
@@ -54,31 +50,6 @@ public final class StartupProperties extends ApplicationProperties {
     private StartupProperties() throws FalconException {
         super();
         resolveAlias();
-    }
-
-    private void resolveAlias() throws FalconException {
-        try {
-            final Configuration conf = new Configuration();
-            String providerPath = getProperty(CREDENTIAL_PROVIDER_PROPERTY);
-            if (providerPath != null) {
-                conf.set(CredentialProviderHelper.CREDENTIAL_PROVIDER_PATH, providerPath);
-            }
-
-            Properties aliasProperties = new Properties();
-            for (Object keyObj : keySet()) {
-                String key = (String) keyObj;
-                if (key.startsWith(ALIAS_PROPERTY_PREFIX)) {
-                    String propertyKey = key.substring(ALIAS_PROPERTY_PREFIX.length());
-                    String propertyValue = CredentialProviderHelper.resolveAlias(conf, getProperty(key));
-                    aliasProperties.setProperty(propertyKey, propertyValue);
-                }
-            }
-            LOG.info("Resolved alias properties: {}", aliasProperties.stringPropertyNames());
-            putAll(aliasProperties);
-        } catch (Exception e) {
-            LOG.error("Exception while resolving credential alias", e);
-            throw new FalconException("Exception while resolving credential alias", e);
-        }
     }
 
     @Override

--- a/common/src/main/java/org/apache/falcon/util/StartupProperties.java
+++ b/common/src/main/java/org/apache/falcon/util/StartupProperties.java
@@ -20,6 +20,8 @@ package org.apache.falcon.util;
 
 import org.apache.falcon.FalconException;
 import org.apache.falcon.hadoop.HadoopClientFactory;
+import org.apache.falcon.security.CredentialProviderHelper;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
@@ -37,6 +39,9 @@ public final class StartupProperties extends ApplicationProperties {
     public static final String SAFEMODE_PROPERTY = "falcon.safeMode";
     private static final String SAFEMODE_FILE = ".safemode";
     private static final String CONFIGSTORE_PROPERTY = "config.store.uri";
+    private static final String CREDENTIAL_PROVIDER_PROPERTY = "hadoop.security.credential.provider.path";
+    private static final String ALIAS_PROPERTY_PREFIX = "hadoop.security.alias.";
+
     private static FileSystem fileSystem;
     private static Path storePath;
 
@@ -48,6 +53,32 @@ public final class StartupProperties extends ApplicationProperties {
 
     private StartupProperties() throws FalconException {
         super();
+        resolveAlias();
+    }
+
+    private void resolveAlias() throws FalconException {
+        try {
+            final Configuration conf = new Configuration();
+            String providerPath = getProperty(CREDENTIAL_PROVIDER_PROPERTY);
+            if (providerPath != null) {
+                conf.set(CredentialProviderHelper.CREDENTIAL_PROVIDER_PATH, providerPath);
+            }
+
+            Properties aliasProperties = new Properties();
+            for (Object keyObj : keySet()) {
+                String key = (String) keyObj;
+                if (key.startsWith(ALIAS_PROPERTY_PREFIX)) {
+                    String propertyKey = key.substring(ALIAS_PROPERTY_PREFIX.length());
+                    String propertyValue = CredentialProviderHelper.resolveAlias(conf, getProperty(key));
+                    aliasProperties.setProperty(propertyKey, propertyValue);
+                }
+            }
+            LOG.info("Resolved alias properties: {}", aliasProperties.stringPropertyNames());
+            putAll(aliasProperties);
+        } catch (Exception e) {
+            LOG.error("Exception while resolving credential alias", e);
+            throw new FalconException("Exception while resolving credential alias", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
Tested alias properties being resolved correctly with Hadoop credential provider.