### PR TITLE
FALCON-1969 Provide server-side error details on CLI, if any

### DIFF
--- a/client/src/main/java/org/apache/falcon/client/FalconCLIException.java
+++ b/client/src/main/java/org/apache/falcon/client/FalconCLIException.java
@@ -47,7 +47,7 @@ public class FalconCLIException extends Exception {
         ClientResponse.Status status = clientResponse.getClientResponseStatus();
         String statusValue = status.toString();
         String message = "";
-        if (status == ClientResponse.Status.BAD_REQUEST) {
+        if (status == ClientResponse.Status.BAD_REQUEST || status == ClientResponse.Status.INTERNAL_SERVER_ERROR) {
             clientResponse.bufferEntity();
             InputStream in = clientResponse.getEntityInputStream();
             try {

--- a/client/src/main/java/org/apache/falcon/client/FalconCLIException.java
+++ b/client/src/main/java/org/apache/falcon/client/FalconCLIException.java
@@ -47,21 +47,19 @@ public class FalconCLIException extends Exception {
         ClientResponse.Status status = clientResponse.getClientResponseStatus();
         String statusValue = status.toString();
         String message = "";
-        if (status == ClientResponse.Status.BAD_REQUEST || status == ClientResponse.Status.INTERNAL_SERVER_ERROR) {
-            clientResponse.bufferEntity();
-            InputStream in = clientResponse.getEntityInputStream();
+        clientResponse.bufferEntity();
+        InputStream in = clientResponse.getEntityInputStream();
+        try {
+            in.mark(MB);
+            message = clientResponse.getEntity(APIResult.class).getMessage();
+        } catch (Throwable th) {
+            byte[] data = new byte[MB];
             try {
-                in.mark(MB);
-                message = clientResponse.getEntity(APIResult.class).getMessage();
-            } catch (Throwable th) {
-                byte[] data = new byte[MB];
-                try {
-                    in.reset();
-                    int len = in.read(data);
-                    message = new String(data, 0, len);
-                } catch (IOException e) {
-                    message = e.getMessage();
-                }
+                in.reset();
+                int len = in.read(data);
+                message = new String(data, 0, len);
+            } catch (IOException e) {
+                message = e.getMessage();
             }
         }
         return new FalconCLIException(statusValue + ";" + message);


### PR DESCRIPTION
Here is a sample CLI output for comparison.

Before:
_[ambari-qa@sandbox falcon-0.10-SNAPSHOT]$ bin/falcon extension -submit -extensionName hdfs-mirroring -file /tmp/falcon-xml/hdfs-mirror-para.txt 
Hadoop is installed, adding hadoop classpath to falcon classpath
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/usr/hdp/2.4.0.0-169/falcon-0.10-SNAPSHOT/client/lib/slf4j-log4j12-1.7.5.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/hdp/2.4.0.0-169/falcon-0.10-SNAPSHOT/client/lib/falcon-cli-0.10-SNAPSHOT.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/hdp/2.4.0.0-169/hadoop/lib/slf4j-log4j12-1.7.10.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
ERROR: Internal Server Error;_

After:
_[ambari-qa@sandbox falcon-0.10-SNAPSHOT]$ bin/falcon extension -submit -extensionName hdfs-mirroring -file /tmp/falcon-xml/hdfs-mirror-para.txt
Hadoop is installed, adding hadoop classpath to falcon classpath
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/usr/hdp/2.4.0.0-169/falcon-0.10-SNAPSHOT/client/lib/slf4j-log4j12-1.7.5.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/hdp/2.4.0.0-169/falcon-0.10-SNAPSHOT/client/lib/falcon-cli-0.10-SNAPSHOT.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/hdp/2.4.0.0-169/hadoop/lib/slf4j-log4j12-1.7.10.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
ERROR: Internal Server Error;**Missing extension property: jobName**_
