### PR TITLE
FALCON-1983 Upgrade jackson core and databind versions to fix dependency incompatibility with higher-version Hive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
         <spark.version>1.6.1</spark.version>
         <jetty.version>6.1.26</jetty.version>
         <jersey.version>1.9</jersey.version>
+        <jackson.version>2.2.3</jackson.version>
         <quartz.version>2.2.1</quartz.version>
         <joda.version>2.8.2</joda.version>
         <mockito.version>1.9.5</mockito.version>
@@ -630,15 +631,21 @@
             </dependency>
 
             <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-core-asl</artifactId>
-                <version>1.9.2</version>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-mapper-asl</artifactId>
-                <version>1.9.2</version>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Tested it works and generates consistent jackson jars with Hive 1.2.1x.