### PR TITLE
FALCON-1984 Provide proper hint and documentation if required titan storage backend is not configured in startup.properties

### DIFF
--- a/common/src/main/resources/startup.properties
+++ b/common/src/main/resources/startup.properties
@@ -156,9 +156,20 @@ it.workflow.execution.listeners=org.apache.falcon.catalog.CatalogPartitionHandle
 *.falcon.graph.blueprints.graph=com.thinkaurelius.titan.core.TitanFactory
 
 # Graph Storage
-*.falcon.graph.storage.directory=${user.dir}/target/graphdb
-*.falcon.graph.storage.backend=berkeleyje
-*.falcon.graph.serialize.path=${user.dir}/target/graphdb
+# IMPORTANT:   Please enable one of the graph db backend: hbase or berkeleydb, per instructions below.
+
+# Enable the following for Berkeley DB.  Make sure je-5.0.73.jar is downloaded and available
+# under Falcon webapp directory or under falcon server classpath.
+#*.falcon.graph.storage.backend=berkeleyje
+#*.falcon.graph.storage.directory=/${falcon.home}/data/graphdb
+#*.falcon.graph.serialize.path=${user.dir}/target/graphdb
+
+# Enable the following for HBase
+#*.falcon.graph.storage.backend=hbase
+# For standalone mode , set hostname to localhost; for distributed mode, set to the zookeeper quorum
+# @see http://s3.thinkaurelius.com/docs/titan/current/hbase.html#_remote_server_mode_2
+#*.falcon.graph.storage.hostname=localhost
+#*.falcon.graph.storage.hbase.table=falcon_titan
 
 # Avoid acquiring read lock when iterating over large graphs
 # See http://s3.thinkaurelius.com/docs/titan/0.5.4/bdb.html

--- a/common/src/test/java/org/apache/falcon/metadata/MetadataMappingServiceTest.java
+++ b/common/src/test/java/org/apache/falcon/metadata/MetadataMappingServiceTest.java
@@ -122,8 +122,10 @@ public class MetadataMappingServiceTest {
         configStore = ConfigurationStore.get();
 
         Services.get().register(new WorkflowJobEndNotificationService());
-        StartupProperties.get().setProperty("falcon.graph.storage.directory",
-                "target/graphdb-" + System.currentTimeMillis());
+        StartupProperties.get().setProperty("falcon.graph.storage.backend", "berkeleyje");
+        String graphDBDir = "target/graphdb-" + System.currentTimeMillis();
+        StartupProperties.get().setProperty("falcon.graph.storage.directory", graphDBDir);
+        StartupProperties.get().setProperty("falcon.graph.serialize.path", graphDBDir);
         StartupProperties.get().setProperty("falcon.graph.preserve.history", "true");
         service = new MetadataMappingService();
         service.init();

--- a/docs/src/site/twiki/Configuration.twiki
+++ b/docs/src/site/twiki/Configuration.twiki
@@ -325,10 +325,16 @@ to <verbatim>$FALCON_HOME/conf/startup.properties</verbatim> before starting the
 For details on the same, refer to [[FalconNativeScheduler][Falcon Native Scheduler]]
 
 ---+++Titan GraphDB backend
-You can either choose to use 5.0.73 version of berkeleydb (the default for Falcon for the last few releases) or 1.1.x or later version HBase as the backend database. Falcon in its release distributions will have the titan storage plugins for both BerkeleyDB and HBase.
+GraphDB backend needs to be configured to properly start Falcon server.
+You can either choose to use 5.0.73 version of berkeleydb (the default for Falcon for the last few releases) or 1.1.x or later version HBase as the backend database.
+Falcon in its release distributions will have the titan storage plugins for both BerkeleyDB and HBase.
 
 ----++++Using BerkeleyDB backend
-Falcon distributions may not package berkeley db artifacts (je-5.0.73.jar) based on build profiles.  If Berkeley DB is not packaged, you can download the Berkeley DB jar file from the URL: <verbatim>http://download.oracle.com/otn/berkeley-db/je-5.0.73.zip</verbatim>.   The following properties describe an example berkeley db graph storage backend that can be specified in the configuration file <verbatim>$FALCON_HOME/conf/startup.properties</verbatim>.
+Falcon distributions may not package berkeley db artifacts (je-5.0.73.jar) based on build profiles.
+If Berkeley DB is not packaged, you can download the Berkeley DB jar file from the URL:
+<verbatim>http://download.oracle.com/otn/berkeley-db/je-5.0.73.zip</verbatim>.
+The following properties describe an example berkeley db graph storage backend that can be specified in the configuration file
+<verbatim>$FALCON_HOME/conf/startup.properties</verbatim>.
 
 <verbatim>
 # Graph Storage

--- a/prism/src/test/java/org/apache/falcon/resource/metadata/MetadataTestContext.java
+++ b/prism/src/test/java/org/apache/falcon/resource/metadata/MetadataTestContext.java
@@ -95,6 +95,10 @@ public class MetadataTestContext {
         Services.get().register(new WorkflowJobEndNotificationService());
         Assert.assertTrue(Services.get().isRegistered(WorkflowJobEndNotificationService.SERVICE_NAME));
 
+        StartupProperties.get().setProperty("falcon.graph.storage.backend", "berkeleyje");
+        String graphDBDir = "target/graphdb-" + System.currentTimeMillis();
+        StartupProperties.get().setProperty("falcon.graph.storage.directory", graphDBDir);
+        StartupProperties.get().setProperty("falcon.graph.serialize.path", graphDBDir);
         StartupProperties.get().setProperty("falcon.graph.preserve.history", "true");
         service = new MetadataMappingService();
         service.init();

--- a/src/conf/startup.properties
+++ b/src/conf/startup.properties
@@ -173,25 +173,19 @@ prism.configstore.listeners=org.apache.falcon.entity.v0.EntityGraph,\
 *.falcon.graph.blueprints.graph=com.thinkaurelius.titan.core.TitanFactory
 
 # Graph Storage
-# IMPORTANT:   Please enable one of hbase or berkeleydb backends are enabled
-#  after the backend requirements are provisioned as needed.
+# IMPORTANT:   Please enable one of the graph db backend: hbase or berkeleydb, per instructions below.
 
-# Enable the following for Berkeley DB.  Make sure je-5.0.73.jar is
-# downloaded and available under Falcon webapp directory or under falcon
-# server classpath.
-
-#*.falcon.graph.storage.directory=/${falcon.home}/data/graphdb
+# Enable the following for Berkeley DB.  Make sure je-5.0.73.jar is downloaded and available
+# under Falcon webapp directory or under falcon server classpath.
 #*.falcon.graph.storage.backend=berkeleyje
-
+#*.falcon.graph.storage.directory=/${falcon.home}/data/graphdb
+#*.falcon.graph.serialize.path=${user.dir}/target/graphdb
 
 # Enable the following for HBase
 #*.falcon.graph.storage.backend=hbase
-#For standalone mode , set hostname to localhost
-#for distributed mode, set to the zookeeper quorum
+# For standalone mode , set hostname to localhost; for distributed mode, set to the zookeeper quorum
 # @see http://s3.thinkaurelius.com/docs/titan/current/hbase.html#_remote_server_mode_2
-
 #*.falcon.graph.storage.hostname=localhost
-#*.falcon.graph.serialize.path=${user.dir}/target/graphdb
 #*.falcon.graph.storage.hbase.table=falcon_titan
 
 # Avoid acquiring read lock when iterating over large graphs


### PR DESCRIPTION
Added validation of required configuration properties for graph db storage backend.
Added error hints on the missing property in Falcon server log.
Reorganized the order of the configuration properties in startup.properties so relevant properties for each backend are grouped in consecutive lines.