### PR TITLE
FALCON-2007 : Hive DR Replication failing with - Can not create a Path from a null string

### DIFF
--- a/addons/hivedr/src/main/java/org/apache/falcon/hive/util/HiveDRUtils.java
+++ b/addons/hivedr/src/main/java/org/apache/falcon/hive/util/HiveDRUtils.java
@@ -70,13 +70,16 @@ public final class HiveDRUtils {
 
     public static Configuration getDefaultConf() throws IOException {
         Configuration conf = new Configuration();
-        Path confPath = new Path("file:///", System.getProperty("oozie.action.conf.xml"));
 
-        final boolean actionConfExists = confPath.getFileSystem(conf).exists(confPath);
-        LOG.info("Oozie Action conf {} found ? {}", confPath, actionConfExists);
-        if (actionConfExists) {
-            LOG.info("Oozie Action conf found, adding path={}, conf={}", confPath, conf.toString());
-            conf.addResource(confPath);
+        if (System.getProperty("oozie.action.conf.xml") != null) {
+            Path confPath = new Path("file:///", System.getProperty("oozie.action.conf.xml"));
+
+            final boolean actionConfExists = confPath.getFileSystem(conf).exists(confPath);
+            LOG.info("Oozie Action conf {} found ? {}", confPath, actionConfExists);
+            if (actionConfExists) {
+                LOG.info("Oozie Action conf found, adding path={}, conf={}", confPath, conf.toString());
+                conf.addResource(confPath);
+            }
         }
 
         String tokenFile = System.getenv("HADOOP_TOKEN_FILE_LOCATION");


### PR DESCRIPTION
Following is the pull request that will check the existence of the file oozie.action.conf.xml. If file is not there, then it will not get into the code block that adds it to the configuration object, thus to avoid the exception.