### PR TITLE
FALCON-2031 : Hcat Retention test cases are failing NoClassDefFoundError

### DIFF
--- a/lifecycle/src/main/resources/action/feed/eviction-action.xml
+++ b/lifecycle/src/main/resources/action/feed/eviction-action.xml
@@ -31,7 +31,7 @@
             <!-- HCatalog jars -->
             <property>
                 <name>oozie.action.sharelib.for.java</name>
-                <value>hcatalog</value>
+                <value>hcatalog,hive</value>
             </property>
             <property>
                 <name>oozie.launcher.oozie.libpath</name>

--- a/oozie/src/main/resources/action/feed/eviction-action.xml
+++ b/oozie/src/main/resources/action/feed/eviction-action.xml
@@ -31,7 +31,7 @@
             <!-- HCatalog jars -->
             <property>
                 <name>oozie.action.sharelib.for.java</name>
-                <value>hcatalog</value>
+                <value>hcatalog,hive</value>
             </property>
             <property>
                 <name>oozie.launcher.oozie.libpath</name>


### PR DESCRIPTION
Please review the following pull request, in which we have added the "oozie.action.sharelib.for.java" = "hcatalog,hive" in eviction-action.xml to avoid the failure of HCat retention test cases with "NoClassDefFoundError" when using latest Hive.