### PR TITLE
FALCON-2035 Entity list operation without type parameter doesn't work when authorization is enabled

### DIFF
--- a/common/src/main/java/org/apache/falcon/security/DefaultAuthorizationProvider.java
+++ b/common/src/main/java/org/apache/falcon/security/DefaultAuthorizationProvider.java
@@ -171,8 +171,8 @@ public class DefaultAuthorizationProvider implements AuthorizationProvider {
                     authorizeAdminResource(authenticatedUGI, action);
                 }
             } else if ("entities".equals(resource) || "instance".equals(resource)) {
-                authorizeEntityResource(authenticatedUGI, entityName, entityType, action,
-                        "entities".equals(resource) && LIST_OPERATION.equals(action));
+                boolean entityTypeOptional = "entities".equals(resource) && LIST_OPERATION.equals(action);
+                authorizeEntityResource(authenticatedUGI, entityName, entityType, action, entityTypeOptional);
             } else if ("metadata".equals(resource)) {
                 authorizeMetadataResource(authenticatedUGI, action);
             }

--- a/common/src/test/java/org/apache/falcon/security/DefaultAuthorizationProviderTest.java
+++ b/common/src/test/java/org/apache/falcon/security/DefaultAuthorizationProviderTest.java
@@ -328,7 +328,7 @@ public class DefaultAuthorizationProviderTest {
                 "admin", realUser, new String[]{"admin", });
 
         DefaultAuthorizationProvider provider = new DefaultAuthorizationProvider();
-        provider.authorizeResource("entities", "list", "clusterz", "primary-cluster", proxyUgi);
+        provider.authorizeResource("instance", "list", "processz", "sample-process", proxyUgi);
         Assert.fail("Bad entity type");
     }
 

--- a/common/src/test/java/org/apache/falcon/security/DefaultAuthorizationProviderTest.java
+++ b/common/src/test/java/org/apache/falcon/security/DefaultAuthorizationProviderTest.java
@@ -315,7 +315,7 @@ public class DefaultAuthorizationProviderTest {
                 "admin", realUser, new String[]{"admin", });
 
         DefaultAuthorizationProvider provider = new DefaultAuthorizationProvider();
-        provider.authorizeResource("entities", "list", null, "primary-cluster", proxyUgi);
+        provider.authorizeResource("instance", "list", null, "sample-process", proxyUgi);
         Assert.fail("Bad entity type");
     }
 


### PR DESCRIPTION
Test entity list operation without type parameter works when authorization is enabled.