### PR TITLE
FALCON-2058 s3 tests with dummy url no longer compatible with latest HDFS

### DIFF
--- a/common/src/test/java/org/apache/falcon/entity/parser/FeedEntityParserTest.java
+++ b/common/src/test/java/org/apache/falcon/entity/parser/FeedEntityParserTest.java
@@ -978,6 +978,7 @@ public class FeedEntityParserTest extends AbstractTestBase {
     }
 
     // disable this test due to its validation of dummy s3 url no longer supported by latest hdfs (2.7.2 or above)
+    @Test (enabled = false)
     public void testValidateACLForArchiveReplication() throws Exception {
         StartupProperties.get().setProperty("falcon.security.authorization.enabled", "true");
         Assert.assertTrue(Boolean.valueOf(

--- a/common/src/test/java/org/apache/falcon/entity/parser/FeedEntityParserTest.java
+++ b/common/src/test/java/org/apache/falcon/entity/parser/FeedEntityParserTest.java
@@ -977,7 +977,7 @@ public class FeedEntityParserTest extends AbstractTestBase {
         }
     }
 
-    @Test
+    // disable this test due to its validation of dummy s3 url no longer supported by latest hdfs (2.7.2 or above)
     public void testValidateACLForArchiveReplication() throws Exception {
         StartupProperties.get().setProperty("falcon.security.authorization.enabled", "true");
         Assert.assertTrue(Boolean.valueOf(


### PR DESCRIPTION
With latest HDFS 2.7.2 or above, falcon's validation with dummy s3 url would fail. Therefore disabling this s3 replication UT. Valid s3 case is already covered in regression tests.