### PR TITLE
FALCON-2073 Handle with NULL corner case

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -206,6 +206,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>falcon-cli-hist.log</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/client/src/main/java/org/apache/falcon/client/FalconClient.java
+++ b/client/src/main/java/org/apache/falcon/client/FalconClient.java
@@ -470,7 +470,7 @@ public class FalconClient extends AbstractFalconClient {
         checkIfSuccessful(clientResponse);
 
         EntityList result = clientResponse.getEntity(EntityList.class);
-        if (result == null || result.getElements() == null) {
+        if (result == null) {
             return new EntityList();
         }
         return result;

--- a/client/src/main/java/org/apache/falcon/client/FalconClient.java
+++ b/client/src/main/java/org/apache/falcon/client/FalconClient.java
@@ -471,7 +471,7 @@ public class FalconClient extends AbstractFalconClient {
 
         EntityList result = clientResponse.getEntity(EntityList.class);
         if (result == null || result.getElements() == null) {
-            return null;
+            return new EntityList();
         }
         return result;
     }

--- a/common/src/main/java/org/apache/falcon/entity/v0/EntityGraph.java
+++ b/common/src/main/java/org/apache/falcon/entity/v0/EntityGraph.java
@@ -56,9 +56,9 @@ public final class EntityGraph implements ConfigurationChangeListener {
 
     public Set<Entity> getDependents(Entity entity) throws FalconException {
         Node entityNode = new Node(entity.getEntityType(), entity.getName());
+        Set<Entity> dependents = new HashSet<Entity>();
         if (graph.containsKey(entityNode)) {
             ConfigurationStore store = ConfigurationStore.get();
-            Set<Entity> dependents = new HashSet<Entity>();
             for (Node node : graph.get(entityNode)) {
                 Entity dependentEntity = store.get(node.type, node.name);
                 if (dependentEntity != null) {
@@ -67,10 +67,10 @@ public final class EntityGraph implements ConfigurationChangeListener {
                     LOG.error("Dependent entity {} was not found in configuration store.", node);
                 }
             }
-            return dependents;
         } else {
-            return null;
+            LOG.error("Entity node {} not found in entity graph.", entityNode);
         }
+        return dependents;
     }
 
     @Override

--- a/common/src/main/java/org/apache/falcon/entity/v0/EntityIntegrityChecker.java
+++ b/common/src/main/java/org/apache/falcon/entity/v0/EntityIntegrityChecker.java
@@ -35,10 +35,6 @@ public final class EntityIntegrityChecker {
 
     public static Pair<String, EntityType>[] referencedBy(Entity entity) throws FalconException {
         Set<Entity> deps = EntityGraph.get().getDependents(entity);
-        if (deps == null) {
-            return null;
-        }
-
         switch (entity.getEntityType()) {
         case CLUSTER:
             return filter(deps, EntityType.FEED, EntityType.PROCESS);

--- a/common/src/test/java/org/apache/falcon/entity/v0/EntityGraphTest.java
+++ b/common/src/test/java/org/apache/falcon/entity/v0/EntityGraphTest.java
@@ -273,10 +273,10 @@ public class EntityGraphTest extends AbstractTestBase {
 
         store.remove(EntityType.PROCESS, process.getName());
         entities = graph.getDependents(cluster);
-        Assert.assertTrue(entities == null);
+        Assert.assertTrue(entities.isEmpty());
 
         entities = graph.getDependents(process);
-        Assert.assertTrue(entities == null);
+        Assert.assertTrue(entities.isEmpty());
     }
 
     @Test
@@ -355,7 +355,7 @@ public class EntityGraphTest extends AbstractTestBase {
         Assert.assertTrue(entities.contains(f3));
 
         entities = graph.getDependents(p2);
-        Assert.assertTrue(entities == null);
+        Assert.assertTrue(entities.isEmpty());
 
         entities = graph.getDependents(f1);
         Assert.assertEquals(entities.size(), 2);
@@ -363,7 +363,7 @@ public class EntityGraphTest extends AbstractTestBase {
         Assert.assertTrue(entities.contains(cluster));
 
         entities = graph.getDependents(f2);
-        Assert.assertTrue(entities == null);
+        Assert.assertTrue(entities.isEmpty());
 
         entities = graph.getDependents(f3);
         Assert.assertEquals(entities.size(), 2);

--- a/oozie/src/main/java/org/apache/falcon/logging/LogProvider.java
+++ b/oozie/src/main/java/org/apache/falcon/logging/LogProvider.java
@@ -113,7 +113,7 @@ public final class LogProvider {
                         + EntityUtil.fromUTCtoURIDate(instance.instance) + "/"
                         + formattedRunId + "/*");
         FileStatus[] actions = fs.globStatus(actionPaths);
-        if (actions.length > 0) {
+        if (actions != null && actions.length > 0) {
             InstanceAction[] instanceActions = new InstanceAction[actions.length - 1];
             instance.actions = instanceActions;
             int i = 0;
@@ -140,8 +140,8 @@ public final class LogProvider {
     }
 
     private String getActionName(String fileName) {
-        return fileName.replaceAll("_SUCCEEDED[.]log", "").replaceAll(
-                "_FAILED[.]log", "");
+        return fileName.replaceAll("_SUCCEEDED\\.log", "").replaceAll(
+                "_FAILED\\.log", "");
     }
 
     private String getActionStatus(String fileName) {

--- a/oozie/src/main/java/org/apache/falcon/logging/LogProvider.java
+++ b/oozie/src/main/java/org/apache/falcon/logging/LogProvider.java
@@ -113,34 +113,35 @@ public final class LogProvider {
                         + EntityUtil.fromUTCtoURIDate(instance.instance) + "/"
                         + formattedRunId + "/*");
         FileStatus[] actions = fs.globStatus(actionPaths);
-        InstanceAction[] instanceActions = new InstanceAction[actions.length - 1];
-        instance.actions = instanceActions;
-        int i = 0;
-        for (FileStatus file : actions) {
-            Path filePath = file.getPath();
-            String dfsBrowserUrl = getDFSbrowserUrl(
-                    ClusterHelper.getStorageUrl(cluster),
-                    EntityUtil.getLogPath(cluster, entity) + "/job-"
-                            + EntityUtil.fromUTCtoURIDate(instance.instance) + "/"
-                            + formattedRunId, file.getPath().getName());
-            if (filePath.getName().equals("oozie.log")) {
-                instance.logFile = dfsBrowserUrl;
-                continue;
+        if (actions.length > 0) {
+            InstanceAction[] instanceActions = new InstanceAction[actions.length - 1];
+            instance.actions = instanceActions;
+            int i = 0;
+            for (FileStatus file : actions) {
+                Path filePath = file.getPath();
+                String dfsBrowserUrl = getDFSbrowserUrl(
+                        ClusterHelper.getStorageUrl(cluster),
+                        EntityUtil.getLogPath(cluster, entity) + "/job-"
+                                + EntityUtil.fromUTCtoURIDate(instance.instance) + "/"
+                                + formattedRunId, file.getPath().getName());
+                if (filePath.getName().equals("oozie.log")) {
+                    instance.logFile = dfsBrowserUrl;
+                    continue;
+                }
+
+                InstanceAction instanceAction = new InstanceAction(
+                        getActionName(filePath.getName()),
+                        getActionStatus(filePath.getName()), dfsBrowserUrl);
+                instanceActions[i++] = instanceAction;
             }
-
-            InstanceAction instanceAction = new InstanceAction(
-                    getActionName(filePath.getName()),
-                    getActionStatus(filePath.getName()), dfsBrowserUrl);
-            instanceActions[i++] = instanceAction;
         }
-
         return instance;
 
     }
 
     private String getActionName(String fileName) {
-        return fileName.replaceAll("_SUCCEEDED.log", "").replaceAll(
-                "_FAILED.log", "");
+        return fileName.replaceAll("_SUCCEEDED[.]log", "").replaceAll(
+                "_FAILED[.]log", "");
     }
 
     private String getActionStatus(String fileName) {

--- a/prism/src/main/java/org/apache/falcon/resource/AbstractEntityManager.java
+++ b/prism/src/main/java/org/apache/falcon/resource/AbstractEntityManager.java
@@ -562,17 +562,15 @@ public abstract class AbstractEntityManager extends AbstractMetadataResource {
 
         //now obtain locks for all dependent entities if any.
         Set<Entity> affectedEntities = EntityGraph.get().getDependents(entity);
-        if (affectedEntities != null) {
-            for (Entity e : affectedEntities) {
-                if (memoryLocks.acquireLock(e, command)) {
-                    tokenList.add(e);
-                    LOG.debug("{} on entity {} has acquired lock on {}", command, entity, e);
-                } else {
-                    LOG.error("Error while trying to acquire lock on {}. Releasing already obtained locks",
-                            e.toShortString());
-                    throw new FalconException("There are multiple update commands running for dependent entity "
-                            + e.toShortString());
-                }
+        for (Entity e : affectedEntities) {
+            if (memoryLocks.acquireLock(e, command)) {
+                tokenList.add(e);
+                LOG.debug("{} on entity {} has acquired lock on {}", command, entity, e);
+            } else {
+                LOG.error("Error while trying to acquire lock on {}. Releasing already obtained locks",
+                        e.toShortString());
+                throw new FalconException("There are multiple update commands running for dependent entity "
+                        + e.toShortString());
             }
         }
     }


### PR DESCRIPTION
Changes:
1. EntityGraph::getDependents should return empty list instead of NULL value if there is no dependent entities. Affected method include OozieWorkflowEngine::updateDependant and AbstractEntityManager::getDependencies. Also removed unnecessary existing NULL checks after the change.
2. In LogProvider::populateActionLogUrls, handle with the NULL case where there is no file status under the specified path.
3. FalconClient::getDependency should return empty list instead of NULL value if there is no dependent entities. Affected method include FalconEntityCLI::entityCommand.

Extra minor changes in this patch:
4. A regular expression misusage in LogProvider::getActionName. To match special character ".", should use "[.]" instead of "." which will try to match any character.
5. Fix a rat check error in Falcon CLI due to the introduction of Spring shell commands.