### PR TITLE
FALCON-2067 In instance status list, -allAttempts does not show all runs

### DIFF
--- a/oozie/src/main/java/org/apache/falcon/workflow/engine/OozieWorkflowEngine.java
+++ b/oozie/src/main/java/org/apache/falcon/workflow/engine/OozieWorkflowEngine.java
@@ -694,9 +694,8 @@ public class OozieWorkflowEngine extends AbstractWorkflowEngine {
                 if (action.equals(JobAction.STATUS) && Boolean.TRUE.equals(allAttempts)) {
                     try {
                         performAction(cluster, action, coordinatorAction, props, instance, isForced);
-                        if (instance.getRunId() > 0) {
-                            instanceList = getAllInstances(cluster, coordinatorAction, nominalTimeStr);
-                        } else {
+                        instanceList = getAllInstances(cluster, coordinatorAction, nominalTimeStr);
+                        if (instanceList.isEmpty()) {
                             instanceList.add(instance);
                         }
                     } catch (FalconException e) {
@@ -883,8 +882,8 @@ public class OozieWorkflowEngine extends AbstractWorkflowEngine {
     private List<InstancesResult.Instance> getAllInstances(String cluster, CoordinatorAction coordinatorAction,
                                                            String nominalTimeStr) throws FalconException {
         List<InstancesResult.Instance> instanceList = new ArrayList<>();
-        if (StringUtils.isNotBlank(coordinatorAction.getExternalId())) {
-            List<WorkflowJob> workflowJobList = getWfsForCoordAction(cluster, coordinatorAction.getExternalId());
+        if (StringUtils.isNotBlank(coordinatorAction.getId())) {
+            List<WorkflowJob> workflowJobList = getWfsForCoordAction(cluster, coordinatorAction.getId());
             if (workflowJobList != null && workflowJobList.size()>0) {
                 for (WorkflowJob workflowJob : workflowJobList) {
                     InstancesResult.Instance newInstance = new InstancesResult.Instance(cluster, nominalTimeStr, null);


### PR DESCRIPTION
After the fix:
`$ bin/falcon instance -status -type process -name oozie-mr-process -start 2013-11-15T00:00Z -allAttempts
Consolidated Status: SUCCEEDED
Instances:
Instance		Cluster		SourceCluster		Status		Start		End		Details					Log
-----------------------------------------------------------------------------------------------
2013-11-15T00:05Z	local	-	READY	-	-	-	-
2013-11-15T00:05Z	local	-	KILLED	2016-07-14T05:53Z	2016-07-14T05:53Z	-	http://IM1738M1:11000/oozie?job=0000006-160713101246755-oozie-oozi-W
actions:
 user-action	ERROR	null
2013-11-15T00:05Z	local	-	KILLED	2016-07-14T05:48Z	2016-07-14T05:51Z	-	http://IM1738M1:11000/oozie?job=0000003-160713101246755-oozie-oozi-W
actions:
 user-action	ERROR	null
 failed-post-processing	KILLED	http://localhost:8088/proxy/application_1468321868387_0012/
2013-11-15T00:10Z	local	-	READY	-	-	-	-
2013-11-15T00:10Z	local	-	KILLED	2016-07-14T05:45Z	2016-07-14T05:48Z	-	http://IM1738M1:11000/oozie?job=0000004-160713101246755-oozie-oozi-W
actions:
 user-action	ERROR	null
 failed-post-processing	KILLED	http://localhost:8088/proxy/application_1468321868387_0011/
2013-11-15T00:15Z	local	-	KILLED	-	-	-	-
2013-11-15T00:20Z	local	-	KILLED	-	-	-	-
2013-11-15T00:25Z	local	-	KILLED	-	-	-	-
2013-11-15T00:30Z	local	-	KILLED	-	-	-	-
2013-11-15T00:35Z	local	-	KILLED	-	-	-	-`