### PR TITLE
FALCON-2115 UT test failure on FalconCSRFFilterTest

### DIFF
--- a/prism/src/test/java/org/apache/falcon/security/FalconCSRFFilterTest.java
+++ b/prism/src/test/java/org/apache/falcon/security/FalconCSRFFilterTest.java
@@ -57,6 +57,7 @@ public class FalconCSRFFilterTest {
     @Test
     public void testCSRFEnabledAllowedMethodFromBrowser() throws Exception {
         StartupProperties.get().setProperty("falcon.security.csrf.enabled", "true");
+        StartupProperties.get().setProperty("falcon.security.csrf.header", FALCON_CSRF_HEADER_DEFAULT);
         mockHeader("Mozilla/5.0", null);
         mockGetMethod();
         mockRunFilter();
@@ -67,6 +68,7 @@ public class FalconCSRFFilterTest {
     @Test
     public void testCSRFEnabledNoCustomHeaderFromBrowser() throws Exception {
         StartupProperties.get().setProperty("falcon.security.csrf.enabled", "true");
+        StartupProperties.get().setProperty("falcon.security.csrf.header", FALCON_CSRF_HEADER_DEFAULT);
         mockHeader("Mozilla/5.0", null);
         mockDeleteMethod();
         mockRunFilter();
@@ -77,6 +79,7 @@ public class FalconCSRFFilterTest {
     @Test
     public void testCSRFEnabledIncludeCustomHeaderFromBrowser() throws Exception {
         StartupProperties.get().setProperty("falcon.security.csrf.enabled", "true");
+        StartupProperties.get().setProperty("falcon.security.csrf.header", FALCON_CSRF_HEADER_DEFAULT);
         mockHeader("Mozilla/5.0", "");
         mockDeleteMethod();
         mockRunFilter();
@@ -87,6 +90,7 @@ public class FalconCSRFFilterTest {
     @Test
     public void testCSRFEnabledAllowNonBrowserInteractionWithoutHeader() throws Exception {
         StartupProperties.get().setProperty("falcon.security.csrf.enabled", "true");
+        StartupProperties.get().setProperty("falcon.security.csrf.header", FALCON_CSRF_HEADER_DEFAULT);
         mockHeader(null, null);
         mockDeleteMethod();
         mockRunFilter();
@@ -97,6 +101,7 @@ public class FalconCSRFFilterTest {
     @Test
     public void testCSRFDisabledAllowAnyMethodFromBrowser() throws Exception {
         StartupProperties.get().setProperty("falcon.security.csrf.enabled", "false");
+        StartupProperties.get().setProperty("falcon.security.csrf.header", FALCON_CSRF_HEADER_DEFAULT);
         mockHeader("Mozilla/5.0", null);
         mockDeleteMethod();
         mockRunFilter();


### PR DESCRIPTION
Need to add the property falcon.security.csrf.header to startup properties when testing custom header for CSRF filter.