### PR TITLE
FALCON-2133: Disable the LogMover from FeedReplication on secure mode. 

### DIFF
--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/FeedReplicationTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/FeedReplicationTest.java
@@ -177,7 +177,7 @@ public class FeedReplicationTest extends BaseTestClass {
         //_SUCCESS should exist in target
         Assert.assertEquals(HadoopUtil.getSuccessFolder(cluster2FS, toTarget, ""), true);
 
-        if(!MerlinConstants.IS_SECURE){
+        if (!MerlinConstants.IS_SECURE){
             AssertUtil.assertLogMoverPath(true, Util.readEntityName(feed.toString()),
                     cluster2FS, "feed", "Success logs are not present");
         }
@@ -283,7 +283,7 @@ public class FeedReplicationTest extends BaseTestClass {
         Assert.assertEquals(HadoopUtil.getSuccessFolder(cluster2FS, toTarget, ""), true);
         Assert.assertEquals(HadoopUtil.getSuccessFolder(cluster3FS, toTarget, ""), true);
 
-        if(!MerlinConstants.IS_SECURE){
+        if (!MerlinConstants.IS_SECURE){
             AssertUtil.assertLogMoverPath(true, Util.readEntityName(feed.toString()),
                     cluster2FS, "feed", "Success logs are not present");
         }
@@ -395,7 +395,7 @@ public class FeedReplicationTest extends BaseTestClass {
         //availabilityFlag should exist in target
         Assert.assertEquals(HadoopUtil.getSuccessFolder(cluster2FS, toTarget, availabilityFlagName), true);
 
-        if(!MerlinConstants.IS_SECURE){
+        if (!MerlinConstants.IS_SECURE){
             AssertUtil.assertLogMoverPath(true, Util.readEntityName(feed.toString()),
                     cluster2FS, "feed", "Success logs are not present");
         }
@@ -570,7 +570,7 @@ public class FeedReplicationTest extends BaseTestClass {
         InstanceUtil.waitTillInstanceReachState(cluster2OC, feed.getName(), 1,
                 CoordinatorAction.Status.KILLED, EntityType.FEED);
 
-        if(!MerlinConstants.IS_SECURE){
+        if (!MerlinConstants.IS_SECURE){
             AssertUtil.assertLogMoverPath(true, Util.readEntityName(feed.toString()),
                     cluster2FS, "feed", "Success logs are not present");
         }

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/FeedReplicationTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/FeedReplicationTest.java
@@ -23,6 +23,7 @@ import org.apache.falcon.entity.v0.feed.ActionType;
 import org.apache.falcon.entity.v0.feed.ClusterType;
 import org.apache.falcon.regression.Entities.FeedMerlin;
 import org.apache.falcon.regression.core.bundle.Bundle;
+import org.apache.falcon.regression.core.enumsAndConstants.MerlinConstants;
 import org.apache.falcon.regression.core.helpers.ColoHelper;
 import org.apache.falcon.regression.core.supportClasses.ExecResult;
 import org.apache.falcon.regression.core.util.AssertUtil;
@@ -176,8 +177,10 @@ public class FeedReplicationTest extends BaseTestClass {
         //_SUCCESS should exist in target
         Assert.assertEquals(HadoopUtil.getSuccessFolder(cluster2FS, toTarget, ""), true);
 
-        AssertUtil.assertLogMoverPath(true, Util.readEntityName(feed.toString()),
-            cluster2FS, "feed", "Success logs are not present");
+        if(!MerlinConstants.IS_SECURE){
+            AssertUtil.assertLogMoverPath(true, Util.readEntityName(feed.toString()),
+                    cluster2FS, "feed", "Success logs are not present");
+        }
 
         ExecResult execResult = cluster1.getFeedHelper().getCLIMetrics(feed.getName());
         AssertUtil.assertCLIMetrics(execResult, feed.getName(), 1, dataFlag);
@@ -280,8 +283,10 @@ public class FeedReplicationTest extends BaseTestClass {
         Assert.assertEquals(HadoopUtil.getSuccessFolder(cluster2FS, toTarget, ""), true);
         Assert.assertEquals(HadoopUtil.getSuccessFolder(cluster3FS, toTarget, ""), true);
 
-        AssertUtil.assertLogMoverPath(true, Util.readEntityName(feed.toString()),
-            cluster2FS, "feed", "Success logs are not present");
+        if(!MerlinConstants.IS_SECURE){
+            AssertUtil.assertLogMoverPath(true, Util.readEntityName(feed.toString()),
+                    cluster2FS, "feed", "Success logs are not present");
+        }
 
         ExecResult execResult = cluster1.getFeedHelper().getCLIMetrics(feed.getName());
         AssertUtil.assertCLIMetrics(execResult, feed.getName(), 1, dataFlag);
@@ -390,8 +395,10 @@ public class FeedReplicationTest extends BaseTestClass {
         //availabilityFlag should exist in target
         Assert.assertEquals(HadoopUtil.getSuccessFolder(cluster2FS, toTarget, availabilityFlagName), true);
 
-        AssertUtil.assertLogMoverPath(true, Util.readEntityName(feed.toString()),
-            cluster2FS, "feed", "Success logs are not present");
+        if(!MerlinConstants.IS_SECURE){
+            AssertUtil.assertLogMoverPath(true, Util.readEntityName(feed.toString()),
+                    cluster2FS, "feed", "Success logs are not present");
+        }
 
         ExecResult execResult = cluster1.getFeedHelper().getCLIMetrics(feed.getName());
         AssertUtil.assertCLIMetrics(execResult, feed.getName(), 1, dataFlag);
@@ -563,8 +570,11 @@ public class FeedReplicationTest extends BaseTestClass {
         InstanceUtil.waitTillInstanceReachState(cluster2OC, feed.getName(), 1,
                 CoordinatorAction.Status.KILLED, EntityType.FEED);
 
-        AssertUtil.assertLogMoverPath(false, Util.readEntityName(feed.toString()),
-                cluster2FS, "feed", "Success logs are not present");
+        if(!MerlinConstants.IS_SECURE){
+            AssertUtil.assertLogMoverPath(true, Util.readEntityName(feed.toString()),
+                    cluster2FS, "feed", "Success logs are not present");
+        }
+
     }
 
     /* Flag value denotes whether to add data for replication or not.

--- a/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/LogMoverTest.java
+++ b/falcon-regression/merlin/src/test/java/org/apache/falcon/regression/LogMoverTest.java
@@ -22,6 +22,7 @@ import org.apache.falcon.entity.v0.EntityType;
 import org.apache.falcon.entity.v0.Frequency.TimeUnit;
 import org.apache.falcon.regression.Entities.ProcessMerlin;
 import org.apache.falcon.regression.core.bundle.Bundle;
+import org.apache.falcon.regression.core.enumsAndConstants.MerlinConstants;
 import org.apache.falcon.regression.core.helpers.ColoHelper;
 import org.apache.falcon.regression.core.util.AssertUtil;
 import org.apache.falcon.regression.core.util.BundleUtil;
@@ -37,7 +38,9 @@ import org.apache.log4j.Logger;
 import org.apache.oozie.client.CoordinatorAction;
 import org.apache.oozie.client.Job;
 import org.apache.oozie.client.OozieClient;
+import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -64,6 +67,13 @@ public class LogMoverTest extends BaseTestClass {
     private String process;
     private String startDate;
     private String endDate;
+
+    @BeforeClass
+    public void checkEnvironment() throws Exception {
+        if (MerlinConstants.IS_SECURE) {
+            throw new SkipException("Skipping tests because LogMover Functionality is not Supported on secure mode.");
+        }
+    }
 
     @BeforeMethod(alwaysRun = true)
     public void setUp() throws Exception {


### PR DESCRIPTION
LogMover is only supported in case of un-secure mode. It has to be disable in the secure mode. In FeedReplication test cases, LogMover assertions will be done after the functionality tested covered. In this cases, we need to verify the functionality but only disable LogMover.
