### PR TITLE
FALCON-2270 Extension job details returns incomplete response

### DIFF
--- a/prism/src/main/java/org/apache/falcon/resource/AbstractExtensionManager.java
+++ b/prism/src/main/java/org/apache/falcon/resource/AbstractExtensionManager.java
@@ -314,9 +314,10 @@ public class AbstractExtensionManager extends AbstractSchedulableEntityManager {
         }
     }
 
-    private JSONObject getEntitiesStatus(List<String> entities, EntityType type) throws JSONException, FalconException {
-        JSONObject entityObject = new JSONObject();
+    private JSONArray getEntitiesStatus(List<String> entities, EntityType type) throws JSONException, FalconException {
+        JSONArray entityObjects = new JSONArray();
         for (String entity : entities) {
+            JSONObject entityObject = new JSONObject();
             try {
                 entityObject.put(NAME, entity);
                 EntityUtil.getEntity(type, entity);
@@ -324,7 +325,8 @@ public class AbstractExtensionManager extends AbstractSchedulableEntityManager {
             } catch (EntityNotRegisteredException e) {
                 entityObject.put(STATUS, ENTITY_NOT_EXISTS_STATUS);
             }
+            entityObjects.put(entityObject);
         }
-        return entityObject;
+        return entityObjects;
     }
 }

--- a/unit/src/test/java/org/apache/falcon/unit/TestFalconUnit.java
+++ b/unit/src/test/java/org/apache/falcon/unit/TestFalconUnit.java
@@ -17,9 +17,17 @@
  */
 package org.apache.falcon.unit;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.ParseException;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import org.apache.falcon.FalconException;
 import org.apache.falcon.FalconWebException;
 import org.apache.falcon.entity.EntityNotRegisteredException;
+import static org.apache.falcon.entity.EntityUtil.getEntity;
 import org.apache.falcon.entity.v0.EntityType;
 import org.apache.falcon.entity.v0.process.Process;
 import org.apache.falcon.entity.v0.process.Property;
@@ -37,20 +45,11 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
+import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import javax.persistence.EntityManager;
-import javax.persistence.Query;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.text.ParseException;
-
-import static org.apache.falcon.entity.EntityUtil.getEntity;
 
 
 /**
@@ -487,11 +486,13 @@ public class TestFalconUnit extends FalconUnitTestBase {
         assertStatus(apiResult);
 
         String processes = new JSONObject(getExtensionJobDetails(TEST_JOB).getMessage()).get("processes").toString();
+        JSONArray processObjects = new JSONArray();
         JSONObject processObject = new JSONObject();
         processObject.put("name", "sample");
         processObject.put("status", "EXISTS");
+        processObjects.put(processObject);
 
-        Assert.assertEquals(processes, processObject.toString());
+        Assert.assertEquals(processes, processObjects.toString());
         process = (Process) getClient().getDefinition(EntityType.PROCESS.toString(), "sample", null);
         Assert.assertEquals(process.getPipelines(), "testSample");
 


### PR DESCRIPTION
Dev tested:
` bin/falcon extension -detail -jobName i1
{
  "jobName": "i1",
  "extensionName": "sample",
  "feeds": [
    {
      "name": "i1-input-feed",
      "status": "EXISTS"
    },
    {
      "name": "i1-output-feed",
      "status": "EXISTS"
    }
  ],
  "processes": [
    {
      "name": "i1-ProcessRecipe-test",
      "status": "EXISTS"
    }
  ],
  "creationTime": "Tue Jan 31 17:35:56 IST 2017",
  "lastUpdatedTime": "Tue Jan 31 17:35:56 IST 2017",
  "location": "hdfs://192.168.138.236:8020/tmp/extensions/extension-example",
  "type": "Custom extension"
}
`