### PR TITLE
FALCON-2267 Definition api fails if resources are empty

### DIFF
--- a/cli/src/main/java/org/apache/falcon/cli/FalconExtensionCLI.java
+++ b/cli/src/main/java/org/apache/falcon/cli/FalconExtensionCLI.java
@@ -92,7 +92,6 @@ public class FalconExtensionCLI extends FalconCLI{
         } else if (optionsList.contains(DEFINITION_OPT)) {
             validateRequiredParameter(extensionName, EXTENSION_NAME_OPT);
             result = client.getExtensionDefinition(extensionName).getMessage();
-            result = prettyPrintJson(result);
         } else if (optionsList.contains(DESCRIBE_OPT)) {
             validateRequiredParameter(extensionName, EXTENSION_NAME_OPT);
             result = client.getExtensionDescription(extensionName).getMessage();

--- a/extensions/src/main/java/org/apache/falcon/extensions/store/ExtensionStore.java
+++ b/extensions/src/main/java/org/apache/falcon/extensions/store/ExtensionStore.java
@@ -18,6 +18,15 @@
 
 package org.apache.falcon.extensions.store;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.apache.falcon.FalconException;
 import org.apache.falcon.entity.parser.ValidationException;
@@ -40,16 +49,6 @@ import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Store for Falcon extensions.
@@ -114,8 +113,9 @@ public final class ExtensionStore {
     }
 
     private String getShortDescription(final String extensionName) throws FalconException {
-        String content = getResource(extensionName, extensionName.toLowerCase()
-                + EXTENSION_PROPERTY_JSON_SUFFIX);
+        String location = storePath.toString() + "/" + extensionName + "/META/"
+                + extensionName.toLowerCase() + EXTENSION_PROPERTY_JSON_SUFFIX;
+        String content = getResource(location);
         String description;
         try {
             JSONObject jsonObject = new JSONObject(content);
@@ -139,40 +139,6 @@ public final class ExtensionStore {
         } catch (Exception e) {
             throw new RuntimeException("Unable to bring up extension store for path: " + storePath, e);
         }
-    }
-
-    private Map<String, String> getExtensionArtifacts(final String extensionName) throws
-            FalconException {
-        Map<String, String> extensionFileMap = new HashMap<>();
-        Path extensionPath;
-        try {
-            RemoteIterator<LocatedFileStatus> fileStatusListIterator;
-            if (AbstractExtension.isExtensionTrusted(extensionName)) {
-                extensionPath = new Path(storePath, extensionName.toLowerCase());
-                fileStatusListIterator = fs.listFiles(extensionPath, true);
-            } else {
-                ExtensionBean extensionBean = metaStore.getDetail(extensionName);
-                if (null == extensionBean) {
-                    throw new StoreAccessException("Extension not found:" + extensionName);
-                }
-                extensionPath = new Path(extensionBean.getLocation());
-                FileSystem fileSystem = getHdfsFileSystem(extensionBean.getLocation());
-                fileStatusListIterator = fileSystem.listFiles(extensionPath, true);
-            }
-
-            if (!fileStatusListIterator.hasNext()) {
-                throw new StoreAccessException(" For extension " + extensionName
-                        + " there are no artifacts at the extension store path " + storePath);
-            }
-            while (fileStatusListIterator.hasNext()) {
-                LocatedFileStatus fileStatus = fileStatusListIterator.next();
-                Path filePath = fileStatus.getPath();
-                extensionFileMap.put(filePath.getName(), filePath.toString());
-            }
-        } catch (IOException e) {
-            throw new StoreAccessException(e);
-        }
-        return extensionFileMap;
     }
 
 
@@ -340,7 +306,7 @@ public final class ExtensionStore {
         }
         FileStatus[] propStatus;
         try {
-            propStatus = fileSystem.listStatus(new Path(uri.getPath() + "/META"));
+            propStatus = fileSystem.listStatus(new Path(uri.getPath() , "META"));
             if (propStatus.length <= 0) {
                 throw new ValidationException("No properties file is not present in the " + uri.getPath() + "/META"
                         + " structure.");
@@ -360,13 +326,30 @@ public final class ExtensionStore {
         return "Extension :" + extensionName + " registered successfully.";
     }
 
-    public String getResource(final String extensionName, final String resourceName) throws FalconException {
-        Map<String, String> resources = getExtensionArtifacts(extensionName);
-        if (resources.isEmpty()) {
-            throw new StoreAccessException("No extension resources found for " + extensionName);
+    public String getResource(final String extensionResourcePath)
+        throws FalconException {
+        StringBuilder definition = new StringBuilder();
+        Path resourcePath = new Path(extensionResourcePath);
+        FileSystem fileSystem = HadoopClientFactory.get().createFalconFileSystem(resourcePath.toUri());
+        try {
+            if (fileSystem.isFile(resourcePath)) {
+                definition.append(getExtensionResource(extensionResourcePath.toString()));
+            } else {
+                RemoteIterator<LocatedFileStatus> fileStatusListIterator = fileSystem.listFiles(resourcePath, false);
+                while (fileStatusListIterator.hasNext()) {
+                    LocatedFileStatus fileStatus = fileStatusListIterator.next();
+                    Path filePath = fileStatus.getPath();
+                    definition.append("Contents of file ").append(filePath.getName()).append(":\n");
+                    definition.append(getExtensionResource(filePath.toString())).append("\n \n");
+                }
+            }
+        } catch (IOException e) {
+            LOG.error("Exception while getting file(s) with path : " + extensionResourcePath, e);
+            throw new StoreAccessException(e);
         }
 
-        return getExtensionResource(resources.get(resourceName));
+        return definition.toString();
+
     }
 
     public Path getExtensionStorePath() {

--- a/extensions/src/test/java/org/apache/falcon/extensions/store/ExtensionStoreTest.java
+++ b/extensions/src/test/java/org/apache/falcon/extensions/store/ExtensionStoreTest.java
@@ -50,7 +50,7 @@ import java.util.Map;
 public class ExtensionStoreTest extends AbstractTestExtensionStore {
     private static Map<String, String> resourcesMap;
     private static JailedFileSystem fs;
-    protected static final String EXTENSION_PATH = "/projects/falcon/extension";
+    protected static final String EXTENSION_PATH = "/projects/falcon/extension/";
     private static final String STORAGE_URL = "jail://global:00";
 
     @BeforeClass
@@ -140,8 +140,7 @@ public class ExtensionStoreTest extends AbstractTestExtensionStore {
         createMETA(extensionPath);
         store = ExtensionStore.get();
         store.registerExtension("toBeDeleted", STORAGE_URL + extensionPath, "test desc", "falconUser");
-        Assert.assertTrue(store.getResource("toBeDeleted", "README").equals("README"));
-        store.getResource("toBeDeleted", "README");
+        Assert.assertTrue(store.getResource(STORAGE_URL + extensionPath + "/README").equals("README"));
         store.deleteExtension("toBeDeleted", "falconUser");
         ExtensionMetaStore metaStore = new ExtensionMetaStore();
         Assert.assertEquals(metaStore.getAllExtensions().size(), 0);

--- a/prism/src/main/java/org/apache/falcon/resource/AbstractExtensionManager.java
+++ b/prism/src/main/java/org/apache/falcon/resource/AbstractExtensionManager.java
@@ -280,13 +280,7 @@ public class AbstractExtensionManager extends AbstractSchedulableEntityManager {
     }
 
     protected static void checkIfExtensionIsEnabled(String extensionName) {
-        ExtensionMetaStore metaStore = ExtensionStore.getMetaStore();
-        ExtensionBean extensionBean = metaStore.getDetail(extensionName);
-        if (extensionBean == null) {
-            LOG.error("Extension not found: " + extensionName);
-            throw FalconWebException.newAPIException("Extension not found:" + extensionName,
-                    Response.Status.NOT_FOUND);
-        }
+        ExtensionBean extensionBean = getExtensionIfExists(extensionName);
         if (!extensionBean.getStatus().equals(ExtensionStatus.ENABLED)) {
             LOG.error("Extension: " + extensionName + " is in disabled state.");
             throw FalconWebException.newAPIException("Extension: " + extensionName + " is in disabled state.",
@@ -294,7 +288,7 @@ public class AbstractExtensionManager extends AbstractSchedulableEntityManager {
         }
     }
 
-    protected static void checkIfExtensionExists(String extensionName) {
+    protected static ExtensionBean getExtensionIfExists(String extensionName) {
         ExtensionMetaStore metaStore = ExtensionStore.getMetaStore();
         ExtensionBean extensionBean = metaStore.getDetail(extensionName);
         if (extensionBean == null) {
@@ -302,6 +296,7 @@ public class AbstractExtensionManager extends AbstractSchedulableEntityManager {
             throw FalconWebException.newAPIException("Extension not found:" + extensionName,
                     Response.Status.NOT_FOUND);
         }
+        return extensionBean;
     }
 
     protected static void checkIfExtensionJobNameExists(String jobName, String extensionName) {


### PR DESCRIPTION
This is extension of @sandeepSamudrala's work on PR 353. Completing it on his behalf as he is out on vacation.

Dev testing done:
`IM1738M1:falcon-0.11-SNAPSHOT pallavi.rao$ bin/falcon extension -enumerate
[
  {
    "name": "sample",
    "type": "Custom extension",
    "location": "hdfs://192.168.138.236:8020/tmp/extensions/extension-example"
  },
  …..
  {
    "name": "hive-mirroring",
    "type": "Trusted extension",
    "description": "This extension implements replicating hive metadata and data from one Hadoop cluster to another Hadoop cluster.",
    "location": "file:/Users/pallavi.rao/falcon/falcon-0.11-SNAPSHOT/extensions/hive-mirroring"
  }
]
IM1738M1:falcon-0.11-SNAPSHOT pallavi.rao$ bin/falcon extension -definition -extensionName hive-mirroring

{
    "shortDescription":"This extension implements replicating hive metadata and data from one Hadoop cluster to another Hadoop cluster.",
    "properties":[
        {
            "propertyName":"jobName",
            "required":true,
            "description":"Unique job name",
            "example":"hive-monthly-sales-dr"
        },
….
    ]
}
IM1738M1:falcon-0.11-SNAPSHOT pallavi.rao$ bin/falcon extension -definition -extensionName sample
Contents of file config:

 
Contents of file config2:
<workflow-app xmlns="uri:oozie:workflow:0.1" name="merlin-workflow">
 ….

 

IM1738M1:falcon-0.11-SNAPSHOT pallavi.rao$ bin/falcon extension -describe -extensionName sample
Extension Test

IM1738M1:falcon-0.11-SNAPSHOT pallavi.rao$ bin/falcon extension -describe -extensionName hive-mirroring
.....
Hive Mirroring Extension

Overview
Falcon provides feature to replicate Hive metadata and data events from source cluster to destination cluster.
…..`