### PR TITLE
[FALCON-2291] Fix the typo in Falcon extensions documentation.

### DIFF
--- a/docs/src/site/twiki/restapi/ExtensionDelete.twiki
+++ b/docs/src/site/twiki/restapi/ExtensionDelete.twiki
@@ -17,7 +17,7 @@ Result of the delete operation.
 ---++ Examples
 ---+++ Rest Call
 <verbatim>
-POST http://localhost:15000/api/extensions/delete/sales-monthly
+POST http://localhost:15000/api/extension/delete/sales-monthly
 </verbatim>
 ---+++ Result
 <verbatim>

--- a/docs/src/site/twiki/restapi/ExtensionInstances.twiki
+++ b/docs/src/site/twiki/restapi/ExtensionInstances.twiki
@@ -25,7 +25,7 @@ A list of entities of the job, each followed by a set of instances.
 ---++ Examples
 ---+++ Rest Call
 <verbatim>
-GET http://localhost:15000/api/extensions/instances/daily-health-bill?start=2012-04-01T00:00
+GET http://localhost:15000/api/extension/instances/daily-health-bill?start=2012-04-01T00:00
 </verbatim>
 ---+++ Result
 <verbatim>

--- a/docs/src/site/twiki/restapi/ExtensionList.twiki
+++ b/docs/src/site/twiki/restapi/ExtensionList.twiki
@@ -18,7 +18,7 @@ Total number of results and a list of jobs implementing the given extension.
 ---++ Examples
 ---+++ Rest Call
 <verbatim>
-GET http://localhost:15000/api/extensions/list/billCollection
+GET http://localhost:15000/api/extension/list/billCollection
 </verbatim>
 ---+++ Result
 <verbatim>

--- a/docs/src/site/twiki/restapi/ExtensionResume.twiki
+++ b/docs/src/site/twiki/restapi/ExtensionResume.twiki
@@ -17,7 +17,7 @@ Result of the resume operation.
 ---++ Examples
 ---+++ Rest Call
 <verbatim>
-POST http://localhost:15000/api/extensions/resume/sales-monthly
+POST http://localhost:15000/api/extension/resume/sales-monthly
 </verbatim>
 ---+++ Result
 <verbatim>

--- a/docs/src/site/twiki/restapi/ExtensionSchedule.twiki
+++ b/docs/src/site/twiki/restapi/ExtensionSchedule.twiki
@@ -17,7 +17,7 @@ Result of the schedule operation.
 ---++ Examples
 ---+++ Rest Call
 <verbatim>
-POST http://localhost:15000/api/extensions/schedule/sales-monthly
+POST http://localhost:15000/api/extension/schedule/sales-monthly
 </verbatim>
 ---+++ Result
 <verbatim>

--- a/docs/src/site/twiki/restapi/ExtensionSubmit.twiki
+++ b/docs/src/site/twiki/restapi/ExtensionSubmit.twiki
@@ -17,7 +17,7 @@ Result of submission.
 ---++ Examples
 ---+++ Rest Call
 <verbatim>
-POST http://localhost:15000/api/extensions/submit/hdfs-mirroring
+POST http://localhost:15000/api/extension/submit/hdfs-mirroring
 jobName=sales-monthly
 jobClustername=primaryCluster
 jobClusterValidityStart=2015-03-13T00:00Z

--- a/docs/src/site/twiki/restapi/ExtensionSubmitAndSchedule.twiki
+++ b/docs/src/site/twiki/restapi/ExtensionSubmitAndSchedule.twiki
@@ -17,7 +17,7 @@ Result of the submit and schedule operation.
 ---++ Examples
 ---+++ Rest Call
 <verbatim>
-POST http://localhost:15000/api/extensions/submitAndSchedule/hdfs-mirroring
+POST http://localhost:15000/api/extension/submitAndSchedule/hdfs-mirroring
 jobName=sales-monthly
 jobClustername=primaryCluster
 jobClusterValidityStart=2015-03-13T00:00Z

--- a/docs/src/site/twiki/restapi/ExtensionSuspend.twiki
+++ b/docs/src/site/twiki/restapi/ExtensionSuspend.twiki
@@ -17,7 +17,7 @@ Result of the suspend operation.
 ---++ Examples
 ---+++ Rest Call
 <verbatim>
-POST http://localhost:15000/api/extensions/suspend/sales-monthly
+POST http://localhost:15000/api/extension/suspend/sales-monthly
 </verbatim>
 ---+++ Result
 <verbatim>

--- a/docs/src/site/twiki/restapi/ExtensionUpdate.twiki
+++ b/docs/src/site/twiki/restapi/ExtensionUpdate.twiki
@@ -17,7 +17,7 @@ Result of update.
 ---++ Examples
 ---+++ Rest Call
 <verbatim>
-POST http://localhost:15000/api/extensions/update/hdfs-mirroring
+POST http://localhost:15000/api/extension/update/hdfs-mirroring
 jobName=sales-monthly
 jobClustername=primaryCluster
 jobClusterValidityStart=2015-03-13T00:00Z

--- a/docs/src/site/twiki/restapi/ExtensionValidate.twiki
+++ b/docs/src/site/twiki/restapi/ExtensionValidate.twiki
@@ -17,7 +17,7 @@ Result of validation.
 ---++ Examples
 ---+++ Rest Call
 <verbatim>
-POST http://localhost:15000/api/extensions/validate/hdfs-mirroring
+POST http://localhost:15000/api/extension/validate/hdfs-mirroring
 jobName=sales-monthly
 jobClustername=primaryCluster
 jobClusterValidityStart=2015-03-13T00:00Z


### PR DESCRIPTION
This PR is used for fixing the typo in Falcon extensions documentation. It looks like "extensions" should be "extension".