### PR TITLE
FALCON-2304 SchedulerServiceTest.testDeRegistration test fails

### DIFF
--- a/scheduler/src/test/java/org/apache/falcon/notification/service/SchedulerServiceTest.java
+++ b/scheduler/src/test/java/org/apache/falcon/notification/service/SchedulerServiceTest.java
@@ -269,7 +269,7 @@ public class SchedulerServiceTest extends AbstractTestBase {
         stateStore.putExecutionInstance(new InstanceState(instance3));
         scheduler.unregister(handler, instance3.getId());
 
-        Thread.sleep(100);
+        Thread.sleep(300);
         Assert.assertEquals(((MockDAGEngine) mockDagEngine).getTotalRuns(instance1), new Integer(1));
         Assert.assertEquals(((MockDAGEngine) mockDagEngine).getTotalRuns(instance2), new Integer(1));
         // Second instance should not run.


### PR DESCRIPTION
The test fails with

```
java.lang.AssertionError: expected:<1> but was:<null>
	at org.testng.Assert.fail(Assert.java:89)
	at org.testng.Assert.failNotEquals(Assert.java:489)
	at org.testng.Assert.assertEquals(Assert.java:118)
	at org.testng.Assert.assertEquals(Assert.java:160)
	at org.apache.falcon.notification.service.SchedulerServiceTest.testDeRegistration(SchedulerServiceTest.java:274)
```
The test passed by increasing the timeout.