### PR TITLE
Falcon 2326 Falcon Pull Request Builds failing

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -155,6 +155,12 @@
             <groupId>org.apache.falcon</groupId>
             <artifactId>falcon-common</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.falcon</groupId>
+                    <artifactId>falcon-metrics</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>

--- a/common/src/main/java/org/apache/falcon/security/AuthenticationInitializationService.java
+++ b/common/src/main/java/org/apache/falcon/security/AuthenticationInitializationService.java
@@ -154,7 +154,6 @@ public class AuthenticationInitializationService implements FalconService {
     private static class TokenValidationThread extends TimerTask {
         @Override
         public void run() {
-
             try {
                 LOG.debug("Revalidating Auth Token at : {} with auth method {}", new Date(),
                         UserGroupInformation.getLoginUser().getAuthenticationMethod().name());

--- a/common/src/main/java/org/apache/falcon/security/AuthenticationInitializationService.java
+++ b/common/src/main/java/org/apache/falcon/security/AuthenticationInitializationService.java
@@ -154,10 +154,15 @@ public class AuthenticationInitializationService implements FalconService {
     private static class TokenValidationThread extends TimerTask {
         @Override
         public void run() {
+
             try {
                 LOG.debug("Revalidating Auth Token at : {} with auth method {}", new Date(),
                         UserGroupInformation.getLoginUser().getAuthenticationMethod().name());
-                UserGroupInformation.getLoginUser().checkTGTAndReloginFromKeytab();
+
+                // Relogin does not work in Hadoop 2.6 or 2.7 as isKeyTab check returns false
+                // UserGroupInformation.getLoginUser().checkTGTAndReloginFromKeytab();
+                // Do a regular loginUserFromKeytab, till the issue is addressed.
+                initializeKerberos();
             } catch (Throwable t) {
                 LOG.error("Error in Auth Token revalidation task: ", t);
                 GenericAlert.initializeKerberosFailed("Exception in Auth Token revalidation : ", t);

--- a/pom.xml
+++ b/pom.xml
@@ -855,19 +855,19 @@
             <dependency>
                 <groupId>org.aspectj</groupId>
                 <artifactId>aspectjrt</artifactId>
-                <version>1.8.6</version>
+                <version>1.8.13</version>
             </dependency>
 
             <dependency>
                 <groupId>org.aspectj</groupId>
                 <artifactId>aspectjweaver</artifactId>
-                <version>1.8.6</version>
+                <version>1.8.13</version>
             </dependency>
 
             <dependency>
                 <groupId>org.aspectj</groupId>
                 <artifactId>aspectjtools</artifactId>
-                <version>1.8.6</version>
+                <version>1.8.13</version>
             </dependency>
 
             <dependency>

--- a/prism/pom.xml
+++ b/prism/pom.xml
@@ -231,29 +231,29 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
-                <version>1.7</version>
+                <version>1.10</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.aspectj</groupId>
                         <artifactId>aspectjweaver</artifactId>
-                        <version>1.8.6</version>
+                        <version>1.8.13</version>
                     </dependency>
                     <dependency>
                         <groupId>org.aspectj</groupId>
                         <artifactId>aspectjrt</artifactId>
-                        <version>1.8.6</version>
+                        <version>1.8.13</version>
                     </dependency>
                     <dependency>
                         <groupId>org.aspectj</groupId>
                         <artifactId>aspectjtools</artifactId>
-                        <version>1.8.6</version>
+                        <version>1.8.13</version>
                     </dependency>
                 </dependencies>
                 <configuration>
                     <verbose>true</verbose>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                    <complianceLevel>1.7</complianceLevel>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <complianceLevel>1.8</complianceLevel>
                     <includes>
                         <include>org/apache/falcon/resource/proxy/SchedulableEntityManagerProxy.java</include>
                         <include>org/apache/falcon/resource/proxy/InstanceManagerProxy.java</include>

--- a/prism/src/test/java/org/apache/falcon/aspect/GenericAlertTest.java
+++ b/prism/src/test/java/org/apache/falcon/aspect/GenericAlertTest.java
@@ -29,5 +29,11 @@ public class GenericAlertTest {
         GenericAlert.instrumentFailedInstance("cluster", "process", "agg-coord", "120:df",
                 "ef-id", "wf-user", "1", "DELETE", "now", "error", "none", 1242);
     }
+
+    @Test
+    public void testRecordAudit() throws Exception {
+        GenericAlert.audit("who", "fromAddress", "fromHost", "whatURL",
+                "whatAddrs", "whenISO9601");
+    }
 }
 


### PR DESCRIPTION
Two clashing versions of AbstractFalconAspect were coming in: One from falcon-cli and another from falcon-prism. The fix is to exclude falcon-metrics from falcon-cli dependency.

While I was at it, I also upgraded aspectj libraries, maven plugin and the java version.