### PR TITLE
FALCON-2334 Tests in UpdateHelperTest suite fails with ParentNotDirectoryException

### DIFF
--- a/common/src/test/java/org/apache/falcon/entity/EntityUtilTest.java
+++ b/common/src/test/java/org/apache/falcon/entity/EntityUtilTest.java
@@ -395,6 +395,7 @@ public class EntityUtilTest extends AbstractTestBase {
         }
 
         Assert.assertEquals(EntityUtil.isStagingPath(cluster, process, path), expected);
+        fs.delete(path);
     }
 
     @DataProvider(name = "bundlePaths")


### PR DESCRIPTION
The UpdateHelperTest tests fails with the following error :
`Parent path is not a directory: /var/lib/jenkins/workspace/falcon/common/target/falcon/tmp-hadoop-jenkins/jail-fs/testCluster/projects/falcon/staging/falcon/workflows/process/sample`

The errors occurs only when the EntityUtilTest#testIsStagingPath test runs before the tests mentioned above.

The following code in EntityUtilTest#testIsStagingPath creates a file at path - target/falcon/tmp-hadoop-jenkins/jail-fs/testCluster/projects/falcon/staging/falcon/workflows/process/sample  which causes the error :

```
if (createPath && !fs.exists(path)) {
 fs.create(path);
 }
```
The change proposed in this pull request deletes the files created in EntityUtilTest#testIsStagingPath after the test checks are done.

